### PR TITLE
fix: add missing SetRelationshipSource

### DIFF
--- a/lib/ash_storage/blob_resource/transformers/setup_blob.ex
+++ b/lib/ash_storage/blob_resource/transformers/setup_blob.ex
@@ -4,7 +4,8 @@ defmodule AshStorage.BlobResource.Transformers.SetupBlob do
 
   @before_transformers [
     Ash.Resource.Transformers.DefaultAccept,
-    Ash.Resource.Transformers.SetTypes
+    Ash.Resource.Transformers.SetTypes,
+    Ash.Resource.Transformers.SetRelationshipSource
   ]
 
   def before?(transformer) when transformer in @before_transformers, do: true


### PR DESCRIPTION
Without this Transformer the source for the :belongs_to relationship on the blob can point to `nil` instead of the blob module.

Without this transformer I would get this error when trying to generate the migrations in my project:

```bash
❯ mix ash.codegen --dev
Compiling 92 files (.ex)
Generated foobar app
Getting extensions in current project...
Running codegen for AshPostgres.DataLayer...
** (ArgumentError) `nil` is not a Spark DSL module.

    nil.persisted(:attributes_by_name)
    (spark 2.6.1) lib/spark/dsl/extension.ex:142: Spark.Dsl.Extension.persisted!/3
    (ash 3.23.1) lib/ash/resource/info.ex:802: Ash.Resource.Info.attribute/2
    (ash_postgres 2.8.0) lib/migration_generator/migration_generator.ex:3350: anonymous fn/4 in AshPostgres.MigrationGenerator.find_reference/3
    (elixir 1.19.5) lib/enum.ex:4487: Enum.find_value_list/3
    (ash_postgres 2.8.0) lib/migration_generator/migration_generator.ex:3308: anonymous fn/3 in AshPostgres.MigrationGenerator.attributes/2
    (elixir 1.19.5) lib/enum.ex:1688: Enum."-map/2-lists^map/1-1-"/2
    (ash_postgres 2.8.0) lib/migration_generator/migration_generator.ex:3152: AshPostgres.MigrationGenerator.do_snapshot/3
```

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
