### PR TITLE
fix: thread tenant context through changes + ops for multitenancy

### DIFF
--- a/lib/ash_storage/changes/attach.ex
+++ b/lib/ash_storage/changes/attach.ex
@@ -13,15 +13,16 @@ defmodule AshStorage.Changes.Attach do
   end
 
   @impl true
-  def change(changeset, opts, _context) do
+  def change(changeset, opts, context) do
     attachment_name = opts[:attachment_name]
+    context_opts = Ash.Context.to_opts(context)
 
     changeset
     |> Ash.Changeset.before_action(fn changeset ->
       record = changeset.data
       resource = record.__struct__
 
-      case do_attach(record, resource, attachment_name, changeset) do
+      case do_attach(record, resource, attachment_name, changeset, context_opts) do
         {:ok, attrs_to_write, attach_context} ->
           changeset
           |> Ash.Changeset.force_change_attributes(attrs_to_write)
@@ -33,15 +34,22 @@ defmodule AshStorage.Changes.Attach do
     end)
     |> Ash.Changeset.after_action(fn changeset, record ->
       case changeset.context[:__ash_storage_attach__] do
-        %{blob: blob, attachment_def: attachment_def, service_mod: service_mod, ctx: ctx} =
-            context ->
+        %{
+          blob: blob,
+          attachment_def: attachment_def,
+          service_mod: service_mod,
+          ctx: ctx,
+          context_opts: context_opts
+        } = attach_context ->
           resource = record.__struct__
 
-          with {:ok, _} <- maybe_replace_existing(record, attachment_def, service_mod, ctx),
-               {:ok, attachment} <- create_attachment(record, attachment_def, blob),
+          with {:ok, _} <-
+                 maybe_replace_existing(record, attachment_def, service_mod, ctx, context_opts),
+               {:ok, attachment} <-
+                 create_attachment(record, attachment_def, blob, context_opts),
                :ok <- run_eager_variants(blob, attachment_def, resource),
                {:ok, blob} <- store_oban_variants(blob, attachment_def, resource) do
-            if context[:has_oban_analyzers?] do
+            if attach_context[:has_oban_analyzers?] do
               AshOban.run_trigger(blob, :run_pending_analyzers)
             end
 
@@ -63,7 +71,7 @@ defmodule AshStorage.Changes.Attach do
     end)
   end
 
-  defp do_attach(record, resource, attachment_name, changeset) do
+  defp do_attach(record, resource, attachment_name, changeset, context_opts) do
     io = Ash.Changeset.get_argument(changeset, :io)
     filename = Ash.Changeset.get_argument(changeset, :filename)
 
@@ -77,7 +85,7 @@ defmodule AshStorage.Changes.Attach do
       ctx = build_context(service_opts, resource, attachment_def, changeset)
 
       with {:ok, blob} <-
-             upload_and_create_blob(resource, service_mod, ctx, io,
+             upload_and_create_blob(resource, service_mod, ctx, io, context_opts,
                filename: filename,
                content_type: content_type,
                metadata: metadata
@@ -89,6 +97,7 @@ defmodule AshStorage.Changes.Attach do
            attachment_def: attachment_def,
            service_mod: service_mod,
            ctx: ctx,
+           context_opts: context_opts,
            has_oban_analyzers?: has_oban_analyzers?(attachment_def)
          }}
       end
@@ -234,7 +243,7 @@ defmodule AshStorage.Changes.Attach do
     end
   end
 
-  defp upload_and_create_blob(resource, service_mod, ctx, io, opts) do
+  defp upload_and_create_blob(resource, service_mod, ctx, io, context_opts, opts) do
     filename = Keyword.fetch!(opts, :filename)
     content_type = Keyword.get(opts, :content_type, "application/octet-stream")
     metadata = Keyword.get(opts, :metadata, %{})
@@ -259,7 +268,7 @@ defmodule AshStorage.Changes.Attach do
           service_opts: persistable_service_opts(service_mod, ctx.service_opts),
           metadata: metadata
         },
-        action: :create
+        Keyword.merge(context_opts, action: :create)
       )
     end
   end
@@ -325,17 +334,24 @@ defmodule AshStorage.Changes.Attach do
   # -- Attachment helpers --
 
   # sobelow_skip ["DOS.BinToAtom"]
-  defp maybe_replace_existing(record, %{type: :one} = attachment_def, service_mod, ctx) do
-    case find_attachments(record, attachment_def) do
+  defp maybe_replace_existing(
+         record,
+         %{type: :one} = attachment_def,
+         service_mod,
+         ctx,
+         context_opts
+       ) do
+    case find_attachments(record, attachment_def, context_opts) do
       {:ok, []} -> {:ok, :noop}
-      {:ok, existing} -> purge_attachments(existing, service_mod, ctx)
+      {:ok, existing} -> purge_attachments(existing, service_mod, ctx, context_opts)
     end
   end
 
-  defp maybe_replace_existing(_record, %{type: :many}, _service_mod, _ctx), do: {:ok, :noop}
+  defp maybe_replace_existing(_record, %{type: :many}, _service_mod, _ctx, _context_opts),
+    do: {:ok, :noop}
 
   # sobelow_skip ["DOS.BinToAtom"]
-  defp create_attachment(record, attachment_def, blob) do
+  defp create_attachment(record, attachment_def, blob, context_opts) do
     resource = record.__struct__
     attachment_resource = Info.storage_attachment_resource!(resource)
 
@@ -367,11 +383,11 @@ defmodule AshStorage.Changes.Attach do
         }
       end
 
-    Ash.create(attachment_resource, params, action: :create)
+    Ash.create(attachment_resource, params, Keyword.merge(context_opts, action: :create))
   end
 
   # sobelow_skip ["DOS.BinToAtom"]
-  defp find_attachments(record, attachment_def) do
+  defp find_attachments(record, attachment_def, context_opts) do
     resource = record.__struct__
     attachment_resource = Info.storage_attachment_resource!(resource)
     record_id = Map.get(record, :id) |> to_string()
@@ -398,16 +414,19 @@ defmodule AshStorage.Changes.Attach do
     attachment_resource
     |> Ash.Query.filter(^filter)
     |> Ash.Query.load(:blob)
+    |> Ash.Query.set_tenant(context_opts[:tenant])
     |> Ash.read()
   end
 
-  defp purge_attachments(attachments, service_mod, ctx) do
+  defp purge_attachments(attachments, service_mod, ctx, context_opts) do
+    destroy_opts = Keyword.merge(context_opts, action: :destroy, return_destroyed?: true)
+
     Enum.reduce_while(attachments, {:ok, []}, fn att, {:ok, acc} ->
       blob = att.blob
 
       with :ok <- service_mod.delete(blob.key, ctx),
-           {:ok, _} <- Ash.destroy(att, action: :destroy, return_destroyed?: true),
-           {:ok, _} <- Ash.destroy(blob, action: :destroy, return_destroyed?: true) do
+           {:ok, _} <- Ash.destroy(att, destroy_opts),
+           {:ok, _} <- Ash.destroy(blob, destroy_opts) do
         {:cont, {:ok, [att | acc]}}
       else
         {:error, error} -> {:halt, {:error, error}}

--- a/lib/ash_storage/changes/attach_blob.ex
+++ b/lib/ash_storage/changes/attach_blob.ex
@@ -42,7 +42,7 @@ defmodule AshStorage.Changes.AttachBlob do
 
   # sobelow_skip ["DOS.BinToAtom"]
   @impl true
-  def change(changeset, opts, _context) do
+  def change(changeset, opts, context) do
     argument_name = opts[:argument]
     attachment_name = opts[:attachment]
 
@@ -53,13 +53,16 @@ defmodule AshStorage.Changes.AttachBlob do
         {:ok, record}
       else
         resource = record.__struct__
+        context_opts = Ash.Context.to_opts(context)
 
         with {:ok, attachment_def} <- Info.attachment(resource, attachment_name),
              {:ok, {service_mod, service_opts}} <- resolve_service(resource, attachment_def),
              ctx = build_context(service_opts, resource, attachment_def, changeset),
-             {:ok, blob} <- fetch_blob(resource, blob_id),
-             {:ok, _} <- maybe_replace_existing(record, attachment_def, service_mod, ctx),
-             {:ok, attachment} <- create_attachment(record, attachment_def, blob) do
+             {:ok, blob} <- fetch_blob(resource, blob_id, context_opts),
+             {:ok, _} <-
+               maybe_replace_existing(record, attachment_def, service_mod, ctx, context_opts),
+             {:ok, attachment} <-
+               create_attachment(record, attachment_def, blob, context_opts) do
           record =
             record
             |> Ash.Resource.put_metadata(:"#{attachment_name}_blob", blob)
@@ -87,26 +90,33 @@ defmodule AshStorage.Changes.AttachBlob do
     )
   end
 
-  defp fetch_blob(resource, blob_id) do
+  defp fetch_blob(resource, blob_id, context_opts) do
     blob_resource = Info.storage_blob_resource!(resource)
 
-    case Ash.get(blob_resource, blob_id) do
+    case Ash.get(blob_resource, blob_id, context_opts) do
       {:ok, blob} -> {:ok, blob}
       {:error, _} -> {:error, :blob_not_found}
     end
   end
 
-  defp maybe_replace_existing(record, %{type: :one} = attachment_def, service_mod, ctx) do
-    case find_attachments(record, attachment_def) do
+  defp maybe_replace_existing(
+         record,
+         %{type: :one} = attachment_def,
+         service_mod,
+         ctx,
+         context_opts
+       ) do
+    case find_attachments(record, attachment_def, context_opts) do
       {:ok, []} -> {:ok, :noop}
-      {:ok, existing} -> purge_attachments(existing, service_mod, ctx)
+      {:ok, existing} -> purge_attachments(existing, service_mod, ctx, context_opts)
     end
   end
 
-  defp maybe_replace_existing(_record, %{type: :many}, _service_mod, _ctx), do: {:ok, :noop}
+  defp maybe_replace_existing(_record, %{type: :many}, _service_mod, _ctx, _context_opts),
+    do: {:ok, :noop}
 
   # sobelow_skip ["DOS.BinToAtom"]
-  defp create_attachment(record, attachment_def, blob) do
+  defp create_attachment(record, attachment_def, blob, context_opts) do
     resource = record.__struct__
     attachment_resource = Info.storage_attachment_resource!(resource)
     record_id = Map.get(record, :id) |> to_string()
@@ -137,11 +147,11 @@ defmodule AshStorage.Changes.AttachBlob do
         }
       end
 
-    Ash.create(attachment_resource, params, action: :create)
+    Ash.create(attachment_resource, params, Keyword.merge(context_opts, action: :create))
   end
 
   # sobelow_skip ["DOS.BinToAtom"]
-  defp find_attachments(record, attachment_def) do
+  defp find_attachments(record, attachment_def, context_opts) do
     resource = record.__struct__
     attachment_resource = Info.storage_attachment_resource!(resource)
     record_id = Map.get(record, :id) |> to_string()
@@ -168,16 +178,19 @@ defmodule AshStorage.Changes.AttachBlob do
     attachment_resource
     |> Ash.Query.filter(^filter)
     |> Ash.Query.load(:blob)
+    |> Ash.Query.set_tenant(context_opts[:tenant])
     |> Ash.read()
   end
 
-  defp purge_attachments(attachments, service_mod, ctx) do
+  defp purge_attachments(attachments, service_mod, ctx, context_opts) do
+    destroy_opts = Keyword.merge(context_opts, action: :destroy, return_destroyed?: true)
+
     Enum.reduce_while(attachments, {:ok, []}, fn att, {:ok, acc} ->
       blob = att.blob
 
       with :ok <- service_mod.delete(blob.key, ctx),
-           {:ok, _} <- Ash.destroy(att, action: :destroy, return_destroyed?: true),
-           {:ok, _} <- Ash.destroy(blob, action: :destroy, return_destroyed?: true) do
+           {:ok, _} <- Ash.destroy(att, destroy_opts),
+           {:ok, _} <- Ash.destroy(blob, destroy_opts) do
         {:cont, {:ok, [att | acc]}}
       else
         {:error, error} -> {:halt, {:error, error}}

--- a/lib/ash_storage/operations.ex
+++ b/lib/ash_storage/operations.ex
@@ -72,11 +72,14 @@ defmodule AshStorage.Operations do
          {:ok, {service_mod, service_opts}} <- resolve_service(resource, attachment_def) do
       ctx = build_context(service_opts, resource, attachment_def, opts)
 
-      filename = Keyword.fetch!(opts, :filename)
-      content_type = Keyword.get(opts, :content_type, "application/octet-stream")
-      byte_size = Keyword.get(opts, :byte_size, 0)
-      checksum = Keyword.get(opts, :checksum, "")
-      metadata = Keyword.get(opts, :metadata, %{})
+      {arg_opts, action_opts} =
+        Keyword.split(opts, [:filename, :content_type, :byte_size, :checksum, :metadata])
+
+      filename = Keyword.fetch!(arg_opts, :filename)
+      content_type = Keyword.get(arg_opts, :content_type, "application/octet-stream")
+      byte_size = Keyword.get(arg_opts, :byte_size, 0)
+      checksum = Keyword.get(arg_opts, :checksum, "")
+      metadata = Keyword.get(arg_opts, :metadata, %{})
 
       key = AshStorage.generate_key()
       blob_resource = Info.storage_blob_resource!(resource)
@@ -94,7 +97,7 @@ defmodule AshStorage.Operations do
                  service_opts: persistable_service_opts(service_mod, service_opts),
                  metadata: metadata
                },
-               action: :create
+               Keyword.merge(action_opts, action: :create)
              ),
            {:ok, upload_info} <- service_mod.direct_upload(key, ctx) do
         {:ok, Map.put(upload_info, :blob, blob)}

--- a/test/ash_storage/multitenancy_test.exs
+++ b/test/ash_storage/multitenancy_test.exs
@@ -1,0 +1,208 @@
+defmodule AshStorage.MultitenancyTest do
+  use ExUnit.Case, async: false
+
+  alias AshStorage.Operations
+
+  defmodule TenantDomain do
+    @moduledoc false
+    use Ash.Domain
+
+    resources do
+      resource AshStorage.MultitenancyTest.TenantBlob
+      resource AshStorage.MultitenancyTest.TenantAttachment
+      resource AshStorage.MultitenancyTest.TenantPost
+    end
+  end
+
+  defmodule TenantBlob do
+    @moduledoc false
+    use Ash.Resource,
+      domain: AshStorage.MultitenancyTest.TenantDomain,
+      data_layer: Ash.DataLayer.Ets,
+      extensions: [AshStorage.BlobResource]
+
+    ets do
+      private? true
+    end
+
+    multitenancy do
+      strategy :context
+    end
+
+    blob do
+    end
+
+    attributes do
+      uuid_primary_key :id
+    end
+  end
+
+  defmodule TenantAttachment do
+    @moduledoc false
+    use Ash.Resource,
+      domain: AshStorage.MultitenancyTest.TenantDomain,
+      data_layer: Ash.DataLayer.Ets,
+      extensions: [AshStorage.AttachmentResource]
+
+    ets do
+      private? true
+    end
+
+    multitenancy do
+      strategy :context
+    end
+
+    attachment do
+      blob_resource(AshStorage.MultitenancyTest.TenantBlob)
+      belongs_to_resource(:tenant_post, AshStorage.MultitenancyTest.TenantPost)
+    end
+
+    attributes do
+      uuid_primary_key :id
+    end
+  end
+
+  defmodule TenantPost do
+    @moduledoc false
+    use Ash.Resource,
+      domain: AshStorage.MultitenancyTest.TenantDomain,
+      data_layer: Ash.DataLayer.Ets,
+      extensions: [AshStorage]
+
+    ets do
+      private? true
+    end
+
+    multitenancy do
+      strategy :context
+    end
+
+    storage do
+      service({AshStorage.Service.Test, []})
+      blob_resource(AshStorage.MultitenancyTest.TenantBlob)
+      attachment_resource(AshStorage.MultitenancyTest.TenantAttachment)
+
+      has_one_attached(:cover_image)
+    end
+
+    attributes do
+      uuid_primary_key :id
+      attribute :title, :string, allow_nil?: false
+    end
+
+    actions do
+      defaults [:read, :destroy, create: [:title], update: [:title]]
+
+      create :create_with_blob do
+        accept [:title]
+        argument :cover_image_blob_id, :uuid, allow_nil?: true
+
+        change {AshStorage.Changes.AttachBlob,
+                argument: :cover_image_blob_id, attachment: :cover_image}
+      end
+    end
+  end
+
+  setup do
+    AshStorage.Service.Test.reset!()
+    %{tenant1: Ash.UUID.generate(), tenant2: Ash.UUID.generate()}
+  end
+
+  describe "Operations.attach with tenant" do
+    test "creates blob and attachment with tenant", %{tenant1: tenant1} do
+      post =
+        TenantPost
+        |> Ash.Changeset.for_create(:create, %{title: "test"}, tenant: tenant1)
+        |> Ash.create!()
+
+      assert {:ok, %{blob: blob, attachment: attachment}} =
+               Operations.attach(post, :cover_image, "hello world",
+                 filename: "hello.txt",
+                 tenant: tenant1
+               )
+
+      assert blob.filename == "hello.txt"
+      assert attachment.blob_id == blob.id
+    end
+
+    test "isolates data between tenants", %{tenant1: tenant1, tenant2: tenant2} do
+      post1 =
+        TenantPost
+        |> Ash.Changeset.for_create(:create, %{title: "post1"}, tenant: tenant1)
+        |> Ash.create!()
+
+      post2 =
+        TenantPost
+        |> Ash.Changeset.for_create(:create, %{title: "post2"}, tenant: tenant2)
+        |> Ash.create!()
+
+      {:ok, %{blob: blob1}} =
+        Operations.attach(post1, :cover_image, "tenant1 data",
+          filename: "t1.txt",
+          tenant: tenant1
+        )
+
+      {:ok, %{blob: blob2}} =
+        Operations.attach(post2, :cover_image, "tenant2 data",
+          filename: "t2.txt",
+          tenant: tenant2
+        )
+
+      assert [att1] = TenantAttachment |> Ash.Query.set_tenant(tenant1) |> Ash.read!()
+      assert att1.blob_id == blob1.id
+
+      assert [att2] = TenantAttachment |> Ash.Query.set_tenant(tenant2) |> Ash.read!()
+      assert att2.blob_id == blob2.id
+    end
+  end
+
+  describe "Operations.prepare_direct_upload with tenant" do
+    test "creates blob with tenant", %{tenant1: tenant1} do
+      {:ok, result} =
+        Operations.prepare_direct_upload(TenantPost, :cover_image,
+          filename: "photo.jpg",
+          content_type: "image/jpeg",
+          byte_size: 12_345,
+          tenant: tenant1
+        )
+
+      assert result.blob.filename == "photo.jpg"
+    end
+  end
+
+  describe "AttachBlob change with tenant" do
+    test "attaches pre-uploaded blob on create", %{tenant1: tenant1} do
+      blob =
+        TenantBlob
+        |> Ash.Changeset.for_create(
+          :create,
+          %{
+            key: AshStorage.generate_key(),
+            filename: "photo.jpg",
+            content_type: "image/jpeg",
+            byte_size: 100,
+            service_name: AshStorage.Service.Test
+          },
+          tenant: tenant1
+        )
+        |> Ash.create!()
+
+      AshStorage.Service.Test.upload(blob.key, "direct data", AshStorage.Service.Context.new([]))
+
+      post =
+        TenantPost
+        |> Ash.Changeset.for_create(
+          :create_with_blob,
+          %{
+            title: "direct upload",
+            cover_image_blob_id: blob.id
+          },
+          tenant: tenant1
+        )
+        |> Ash.create!()
+
+      post = Ash.load!(post, [cover_image: :blob], tenant: tenant1)
+      assert post.cover_image.blob.id == blob.id
+    end
+  end
+end


### PR DESCRIPTION
Fixes multi-tenancy issues across `Attachments`, `Blobs`, and `prepare_direct_upload`. All three were missing the tenant being passed through context.

**Minimal reproduction:**
```
defmodule MyPost do
  use Ash.Resource, extensions: [AshStorage]

  multitenancy do
    strategy :context
  end

  storage do
    service ...
    blob_resource MyBlob
    attachment_resource ...
    has_one_attached :cover_image
  end
end

post = Ash.create!(MyPost, %{title: "test"}, tenant: "org_1")

AshStorage.Operations.attach(post, :cover_image, "data", filename: "photo.jpg", tenant: "org_1")
# => ** (Ash.Error.Invalid) MyBlob changesets require a tenant to be specified
```

The fix is mostly just to pass the tenant/context through. 
- I build the context opts using `Ash.Context.to_opts(context)`. 
- For `prepare_direct_upload` I split `arg_opts` and `action_opts` like the other functions in `operations.ex` and then pass them to `Ash.create`.

# Contributor checklist

Leave anything that you believe does not apply unchecked.
- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [x] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies