### PR TITLE
feat: support attribute_type on belongs_to_resource

### DIFF
--- a/lib/ash_storage/attachment_resource.ex
+++ b/lib/ash_storage/attachment_resource.ex
@@ -70,7 +70,7 @@ defmodule AshStorage.AttachmentResource do
 
   defmodule BelongsToResource do
     @moduledoc "Represents a belongs_to_resource declaration on an attachment resource."
-    defstruct [:name, :resource, :__spark_metadata__]
+    defstruct [:name, :resource, :attribute_type, :__spark_metadata__]
   end
 
   @belongs_to_resource %Spark.Dsl.Entity{
@@ -79,7 +79,8 @@ defmodule AshStorage.AttachmentResource do
     describe:
       "Declares a belongs_to relationship to a parent resource, creating a proper foreign key.",
     examples: [
-      "belongs_to_resource :post, MyApp.Post"
+      "belongs_to_resource :post, MyApp.Post",
+      "belongs_to_resource :post, MyApp.Post, attribute_type: :integer"
     ],
     schema: [
       name: [
@@ -91,6 +92,12 @@ defmodule AshStorage.AttachmentResource do
         type: :module,
         required: true,
         doc: "The parent resource module."
+      ],
+      attribute_type: [
+        type: :any,
+        required: false,
+        doc:
+          "The type of the generated FK attribute. Defaults to `:uuid`. Set to `:integer` if the parent resource uses `integer_primary_key`."
       ]
     ],
     target: BelongsToResource

--- a/lib/ash_storage/attachment_resource/transformers/setup_attachment.ex
+++ b/lib/ash_storage/attachment_resource/transformers/setup_attachment.ex
@@ -55,17 +55,25 @@ defmodule AshStorage.AttachmentResource.Transformers.SetupAttachment do
              public?: true,
              attribute_writable?: true
            ) do
-      Enum.reduce(belongs_to_resources, {:ok, dsl_state}, fn %{name: name, resource: resource},
+      Enum.reduce(belongs_to_resources, {:ok, dsl_state}, fn %{
+                                                               name: name,
+                                                               resource: resource,
+                                                               attribute_type: attribute_type
+                                                             },
                                                              {:ok, dsl_state} ->
-        Ash.Resource.Builder.add_relationship(
-          dsl_state,
-          :belongs_to,
-          name,
-          resource,
-          allow_nil?: true,
-          public?: true,
-          attribute_writable?: true
-        )
+        opts =
+          if attribute_type do
+            [
+              allow_nil?: true,
+              public?: true,
+              attribute_writable?: true,
+              attribute_type: attribute_type
+            ]
+          else
+            [allow_nil?: true, public?: true, attribute_writable?: true]
+          end
+
+        Ash.Resource.Builder.add_relationship(dsl_state, :belongs_to, name, resource, opts)
       end)
     end
   end

--- a/lib/ash_storage/blob_resource/transformers/setup_blob.ex
+++ b/lib/ash_storage/blob_resource/transformers/setup_blob.ex
@@ -4,7 +4,8 @@ defmodule AshStorage.BlobResource.Transformers.SetupBlob do
 
   @before_transformers [
     Ash.Resource.Transformers.DefaultAccept,
-    Ash.Resource.Transformers.SetTypes
+    Ash.Resource.Transformers.SetTypes,
+    Ash.Resource.Transformers.SetRelationshipSource
   ]
 
   def before?(transformer) when transformer in @before_transformers, do: true

--- a/test/ash_storage/attachment_resource_test.exs
+++ b/test/ash_storage/attachment_resource_test.exs
@@ -2,6 +2,7 @@ defmodule AshStorage.AttachmentResourceTest do
   use ExUnit.Case, async: true
 
   alias AshStorage.Test.Attachment
+  alias AshStorage.Test.IntegerAttachment
   alias AshStorage.Test.MultiAttachment
   alias AshStorage.Test.PolymorphicAttachment
 
@@ -103,6 +104,18 @@ defmodule AshStorage.AttachmentResourceTest do
       assert :record_id in action.accept
       assert :blob_id in action.accept
       assert :name in action.accept
+    end
+  end
+
+  describe "belongs_to_resource with attribute_type" do
+    test "generates FK attribute with the specified type" do
+      attr = Ash.Resource.Info.attribute(IntegerAttachment, :post_id)
+      assert attr.type == Ash.Type.Integer
+    end
+
+    test "defaults to UUID type when attribute_type is not set" do
+      attr = Ash.Resource.Info.attribute(Attachment, :post_id)
+      assert attr.type == Ash.Type.UUID
     end
   end
 

--- a/test/support/domain.ex
+++ b/test/support/domain.ex
@@ -12,5 +12,7 @@ defmodule AshStorage.Test.Domain do
     resource AshStorage.Test.ConfigurablePost
     resource AshStorage.Test.AnalyzablePost
     resource AshStorage.Test.VariantPost
+    resource AshStorage.Test.IntegerPost
+    resource AshStorage.Test.IntegerAttachment
   end
 end

--- a/test/support/integer_attachment.ex
+++ b/test/support/integer_attachment.ex
@@ -1,0 +1,20 @@
+defmodule AshStorage.Test.IntegerAttachment do
+  @moduledoc false
+  use Ash.Resource,
+    domain: AshStorage.Test.Domain,
+    data_layer: Ash.DataLayer.Ets,
+    extensions: [AshStorage.AttachmentResource]
+
+  ets do
+    private? true
+  end
+
+  attachment do
+    blob_resource(AshStorage.Test.Blob)
+    belongs_to_resource(:post, AshStorage.Test.IntegerPost, attribute_type: :integer)
+  end
+
+  attributes do
+    uuid_primary_key :id
+  end
+end

--- a/test/support/integer_post.ex
+++ b/test/support/integer_post.ex
@@ -1,0 +1,18 @@
+defmodule AshStorage.Test.IntegerPost do
+  @moduledoc false
+  use Ash.Resource,
+    domain: AshStorage.Test.Domain,
+    data_layer: Ash.DataLayer.Ets
+
+  ets do
+    private? true
+  end
+
+  actions do
+    defaults [:read, :destroy, create: []]
+  end
+
+  attributes do
+    integer_primary_key :id
+  end
+end


### PR DESCRIPTION
  Allow callers to specify the FK attribute type when the parent resource
  does not use the default UUID primary key:

      belongs_to_resource :post, MyApp.Post, attribute_type: :integer

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [x] Documentation changes
- [x] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
