### PR TITLE
Add DSL macros to locals_without_parens formatter option

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,5 +1,30 @@
 # Used by "mix format"
+spark_locals_without_parens = [
+  analyze: 1,
+  analyzer: 1,
+  analyzer: 2,
+  attachment_resource: 1,
+  attribute_type: 1,
+  belongs_to_resource: 2,
+  belongs_to_resource: 3,
+  blob_resource: 1,
+  dependent: 1,
+  generate: 1,
+  has_many_attached: 1,
+  has_many_attached: 2,
+  has_one_attached: 1,
+  has_one_attached: 2,
+  service: 1,
+  variant: 2,
+  variant: 3,
+  write_attributes: 1
+]
+
 [
   inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"],
-  import_deps: [:ash, :spark]
+  import_deps: [:ash, :spark],
+  locals_without_parens: spark_locals_without_parens,
+  export: [
+    locals_without_parens: spark_locals_without_parens
+  ]
 ]

--- a/mix.exs
+++ b/mix.exs
@@ -195,7 +195,9 @@ defmodule AshStorage.MixProject do
       docs: [
         "docs",
         "spark.replace_doc_links"
-      ]
+      ],
+      "spark.formatter":
+        "spark.formatter --extensions AshStorage,AshStorage.BlobResource,AshStorage.AttachmentResource"
     ]
   end
 end


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [x] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

Used Claude to make sure I got all DSL macros and referenced ash_authentication's .formatter.exs as a "style guide" (ie, extracting the `spark_locals_without_parens` variable).

Let me know if it's necessary to document this, it doesn't seem to be documented in other Ash packages I've seen.

Closes #8