### PR TITLE
Add `url` calculation to attachment resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ This automatically adds:
 
 - `has_one :cover_image` / `has_many :documents` relationships to load attachments
 - A `cover_image_url` calculation for each `has_one_attached`
+- A `url` calculation on each attachment record
 
 ## Usage
 
@@ -145,6 +146,11 @@ post.cover_image_url
 post = Ash.load!(post, documents: :blob)
 Enum.map(post.documents, & &1.blob.filename)
 #=> ["report.pdf", "notes.txt"]
+
+# Load URLs via the attachment's url calculation
+post = Ash.load!(post, documents: [:url])
+Enum.map(post.documents, & &1.url)
+#=> ["/storage/a81bf21e2442...", "/storage/f9c3e71d8810..."]
 ```
 
 ### Detaching and purging

--- a/lib/ash_storage/attachment_resource/transformers/setup_attachment.ex
+++ b/lib/ash_storage/attachment_resource/transformers/setup_attachment.ex
@@ -20,6 +20,7 @@ defmodule AshStorage.AttachmentResource.Transformers.SetupAttachment do
     dsl_state
     |> add_attributes(belongs_to_resources)
     |> add_relationships(blob_resource, belongs_to_resources)
+    |> add_calculations(belongs_to_resources)
     |> add_actions(belongs_to_resources)
   end
 
@@ -79,6 +80,25 @@ defmodule AshStorage.AttachmentResource.Transformers.SetupAttachment do
   end
 
   defp add_relationships({:error, error}, _, _), do: {:error, error}
+
+  defp add_calculations({:ok, dsl_state}, belongs_to_resources) do
+    parent_resources =
+      Enum.map(belongs_to_resources, fn %{name: name, resource: resource} ->
+        {name, resource}
+      end)
+
+    Ash.Resource.Builder.add_calculation(
+      dsl_state,
+      :url,
+      :string,
+      {AshStorage.Calculations.Url, parent_resources: parent_resources},
+      public?: true,
+      filterable?: false,
+      sortable?: false
+    )
+  end
+
+  defp add_calculations({:error, error}, _), do: {:error, error}
 
   # sobelow_skip ["DOS.BinToAtom"]
   defp add_actions({:ok, dsl_state}, belongs_to_resources) do

--- a/lib/ash_storage/calculations/attachment_url.ex
+++ b/lib/ash_storage/calculations/attachment_url.ex
@@ -3,11 +3,6 @@ defmodule AshStorage.Calculations.AttachmentUrl do
   use Ash.Resource.Calculation
 
   @impl true
-  def init(opts) do
-    {:ok, opts}
-  end
-
-  @impl true
   def strict_loads?, do: false
 
   @impl true

--- a/lib/ash_storage/calculations/attachment_urls.ex
+++ b/lib/ash_storage/calculations/attachment_urls.ex
@@ -3,11 +3,6 @@ defmodule AshStorage.Calculations.AttachmentUrls do
   use Ash.Resource.Calculation
 
   @impl true
-  def init(opts) do
-    {:ok, opts}
-  end
-
-  @impl true
   def strict_loads?, do: false
 
   @impl true

--- a/lib/ash_storage/calculations/url.ex
+++ b/lib/ash_storage/calculations/url.ex
@@ -3,11 +3,6 @@ defmodule AshStorage.Calculations.Url do
   use Ash.Resource.Calculation
 
   @impl true
-  def init(opts) do
-    {:ok, opts}
-  end
-
-  @impl true
   def strict_loads?, do: false
 
   # sobelow_skip ["DOS.BinToAtom"]

--- a/lib/ash_storage/calculations/url.ex
+++ b/lib/ash_storage/calculations/url.ex
@@ -1,0 +1,67 @@
+defmodule AshStorage.Calculations.Url do
+  @moduledoc false
+  use Ash.Resource.Calculation
+
+  @impl true
+  def init(opts) do
+    {:ok, opts}
+  end
+
+  @impl true
+  def strict_loads?, do: false
+
+  # sobelow_skip ["DOS.BinToAtom"]
+  @impl true
+  def load(_query, opts, _context) do
+    case opts[:parent_resources] do
+      [] ->
+        [:name, :record_type, :blob]
+
+      parents ->
+        parent_fields = Enum.map(parents, fn {name, _} -> :"#{name}_id" end)
+        [:name, :blob | parent_fields]
+    end
+  end
+
+  # sobelow_skip ["DOS.BinToAtom"]
+  @impl true
+  def calculate(records, opts, context) do
+    parent_resources = opts[:parent_resources]
+
+    {:ok,
+     Enum.map(records, fn attachment ->
+       with {:ok, resource} <- resolve_parent_resource(attachment, parent_resources),
+            attachment_name = String.to_existing_atom(attachment.name),
+            {:ok, attachment_def} <- AshStorage.Info.attachment(resource, attachment_name),
+            {:ok, {service_mod, service_opts}} <-
+              AshStorage.Info.service_for_attachment(resource, attachment_def) do
+         ctx =
+           AshStorage.Service.Context.new(service_opts,
+             resource: resource,
+             attachment: attachment_def,
+             actor: Map.get(context, :actor),
+             tenant: Map.get(context, :tenant)
+           )
+
+         service_mod.url(attachment.blob.key, ctx)
+       else
+         _ -> nil
+       end
+     end)}
+  end
+
+  # sobelow_skip ["DOS.BinToAtom"]
+  defp resolve_parent_resource(attachment, []) do
+    {:ok, String.to_existing_atom(attachment.record_type)}
+  end
+
+  # sobelow_skip ["DOS.BinToAtom"]
+  defp resolve_parent_resource(attachment, parent_resources) do
+    case Enum.find_value(parent_resources, fn {name, resource} ->
+           if Map.get(attachment, :"#{name}_id") != nil, do: resource
+         end) do
+      nil -> :error
+      resource -> {:ok, resource}
+    end
+  end
+end

--- a/lib/ash_storage/calculations/variant_url.ex
+++ b/lib/ash_storage/calculations/variant_url.ex
@@ -3,11 +3,6 @@ defmodule AshStorage.Calculations.VariantUrl do
   use Ash.Resource.Calculation
 
   @impl true
-  def init(opts) do
-    {:ok, opts}
-  end
-
-  @impl true
   def strict_loads?, do: false
 
   @impl true

--- a/lib/ash_storage/calculations/variant_urls.ex
+++ b/lib/ash_storage/calculations/variant_urls.ex
@@ -3,11 +3,6 @@ defmodule AshStorage.Calculations.VariantUrls do
   use Ash.Resource.Calculation
 
   @impl true
-  def init(opts) do
-    {:ok, opts}
-  end
-
-  @impl true
   def strict_loads?, do: false
 
   @impl true

--- a/lib/ash_storage/transformers/setup_storage.ex
+++ b/lib/ash_storage/transformers/setup_storage.ex
@@ -77,16 +77,10 @@ defmodule AshStorage.Transformers.SetupStorage do
       opts =
         [
           destination_attribute: destination_attribute,
+          validate_destination_attribute?: not is_nil(parent_rel),
           filters: [name_filter],
           public?: true
         ]
-
-      opts =
-        if is_nil(parent_rel) do
-          Keyword.put(opts, :validate_destination_attribute?, false)
-        else
-          opts
-        end
 
       opts =
         if attachment_def.sort do

--- a/test/ash_storage/url_test.exs
+++ b/test/ash_storage/url_test.exs
@@ -64,6 +64,88 @@ defmodule AshStorage.UrlTest do
     end
   end
 
+  describe "attachment URL calculation" do
+    test "returns URL for has_one attachment" do
+      post = create_post!()
+
+      {:ok, %{blob: blob}} =
+        AshStorage.Operations.attach(post, :cover_image, "data",
+          filename: "photo.jpg",
+          content_type: "image/jpeg"
+        )
+
+      post = Ash.load!(post, cover_image: [:url])
+      assert post.cover_image.url == "http://test.local/storage/#{blob.key}"
+    end
+
+    test "returns URLs for has_many attachments" do
+      post = create_post!()
+
+      {:ok, %{blob: blob1}} =
+        AshStorage.Operations.attach(post, :documents, "doc1",
+          filename: "a.txt",
+          content_type: "text/plain"
+        )
+
+      {:ok, %{blob: blob2}} =
+        AshStorage.Operations.attach(post, :documents, "doc2",
+          filename: "b.txt",
+          content_type: "text/plain"
+        )
+
+      post = Ash.load!(post, documents: [:url])
+
+      urls =
+        post.documents
+        |> Enum.map(& &1.url)
+        |> Enum.sort()
+
+      expected =
+        [blob1.key, blob2.key]
+        |> Enum.map(&"http://test.local/storage/#{&1}")
+        |> Enum.sort()
+
+      assert urls == expected
+    end
+  end
+
+  describe "attachment URL calculation with variants" do
+    defp create_variant_post! do
+      AshStorage.Test.VariantPost
+      |> Ash.Changeset.for_create(:create, %{title: "test"})
+      |> Ash.create!()
+    end
+
+    test "returns source blob URL when variants exist" do
+      post = create_variant_post!()
+
+      {:ok, %{blob: blob}} =
+        AshStorage.Operations.attach(post, :document, "hello",
+          filename: "test.txt",
+          content_type: "text/plain"
+        )
+
+      post = Ash.load!(post, document: [:url])
+      assert post.document.url == "http://test.local/storage/#{blob.key}"
+    end
+
+    test "source blob URL is distinct from variant URLs" do
+      post = create_variant_post!()
+
+      {:ok, _} =
+        AshStorage.Operations.attach(post, :document, "hello",
+          filename: "test.txt",
+          content_type: "text/plain"
+        )
+
+      post = Ash.load!(post, [:document_eager_uppercase_url, document: [:url]])
+
+      # Attachment url is the source blob URL
+      # Variant url is a different blob's URL
+      assert post.document.url != post.document_eager_uppercase_url
+    end
+  end
+
   describe "Disk signed URLs" do
     test "generates plain URL without secret" do
       ctx =


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [x] Documentation changes
- [x] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

First off, sorry @StephanH90 if you were planning on doing this, I just wanted this ASAP so I put this together.  If you have WIP you were hoping to PR, I'm happy to close this in favour of anything you've done (not a loss for me as I learned a thing or two!)

---

Adds `url` directly to the attachment resource as per #5.

**Design Trade-off**

This implementation threads the parent resource through the calculation in order to get the `base_url`.  Alternatively, we could store the `base_url` in `AshStorage.Service.Disk.service_opts_fields` however this would be a breaking change.  Note that it would only be breaking for users who would want to use this new functionality and in order to do so, would need to back-fill.  

<details>
<summary>Basically this:</summary>

```elixir
defmodule MyApp.Repo.Migrations.BackfillBlobBaseUrl do
  use Ecto.Migration

  def up do
    execute """
    UPDATE storage_blobs
    SET service_opts = jsonb_set(COALESCE(service_opts, '{}'), '{base_url}', '"/storage"')
    WHERE service_name = 'Elixir.AshStorage.Service.Disk'
    AND (service_opts IS NULL OR NOT service_opts ? 'base_url')
    """
  end

  def down do
    execute """
    UPDATE storage_blobs
    SET service_opts = service_opts - 'base_url'
    WHERE service_name = 'Elixir.AshStorage.Service.Disk'
    """
  end
end
```
</details>

I want to note that I use AI heavily to produce these changes.  I spent around 1.5 hours on this PR going back and forth with Calude Code, gaining a decent grasp of what is going on but I cannot say that I yet have a deep understanding of the inner workings of ash_storage (having built things like this before I have a very good high level understanding I'm just talking more Ash stuff, like Spark).

I have also tried this out in my current project and all seems good there.