### PR TITLE
Add `sort` option to the `has_many_attached`

### DIFF
--- a/lib/ash_storage/attachment_definition.ex
+++ b/lib/ash_storage/attachment_definition.ex
@@ -5,6 +5,7 @@ defmodule AshStorage.AttachmentDefinition do
     :type,
     :service,
     :dependent,
+    :sort,
     :__spark_metadata__,
     analyzers: [],
     variants: []
@@ -36,5 +37,15 @@ defmodule AshStorage.AttachmentDefinition do
   end
 
   def has_one_schema, do: @shared_schema
-  def has_many_schema, do: @shared_schema
+
+  def has_many_schema do
+    @shared_schema ++
+      [
+        sort: [
+          type: :any,
+          doc:
+            "A sort statement to be applied when the relationship is loaded. e.g. `sort: created_at: :desc`"
+        ]
+      ]
+  end
 end

--- a/lib/ash_storage/transformers/setup_storage.ex
+++ b/lib/ash_storage/transformers/setup_storage.ex
@@ -74,14 +74,33 @@ defmodule AshStorage.Transformers.SetupStorage do
         filter: Ash.Expr.expr(name == ^to_string(attachment_def.name))
       }
 
+      opts =
+        [
+          destination_attribute: destination_attribute,
+          filters: [name_filter],
+          public?: true
+        ]
+
+      opts =
+        if is_nil(parent_rel) do
+          Keyword.put(opts, :validate_destination_attribute?, false)
+        else
+          opts
+        end
+
+      opts =
+        if attachment_def.sort do
+          Keyword.put(opts, :sort, attachment_def.sort)
+        else
+          opts
+        end
+
       Ash.Resource.Builder.add_relationship(
         dsl_state,
         rel_type,
         attachment_def.name,
         attachment_resource,
-        destination_attribute: destination_attribute,
-        filters: [name_filter],
-        public?: true
+        opts
       )
     end)
   end

--- a/test/ash_storage/sort_test.exs
+++ b/test/ash_storage/sort_test.exs
@@ -1,0 +1,202 @@
+defmodule AshStorage.SortTest do
+  use ExUnit.Case, async: false
+
+  alias AshStorage.Operations
+
+  defmodule SortDomain do
+    @moduledoc false
+    use Ash.Domain
+
+    resources do
+      resource AshStorage.SortTest.SortBlob
+      resource AshStorage.SortTest.SortAttachment
+      resource AshStorage.SortTest.SortedPost
+      resource AshStorage.SortTest.DoBlockSortedPost
+      resource AshStorage.SortTest.UnsortedPost
+    end
+  end
+
+  defmodule SortBlob do
+    @moduledoc false
+    use Ash.Resource,
+      domain: AshStorage.SortTest.SortDomain,
+      data_layer: Ash.DataLayer.Ets,
+      extensions: [AshStorage.BlobResource]
+
+    ets do
+      private? true
+    end
+
+    blob do
+    end
+
+    attributes do
+      uuid_primary_key :id
+    end
+  end
+
+  defmodule SortAttachment do
+    @moduledoc false
+    use Ash.Resource,
+      domain: AshStorage.SortTest.SortDomain,
+      data_layer: Ash.DataLayer.Ets,
+      extensions: [AshStorage.AttachmentResource]
+
+    ets do
+      private? true
+    end
+
+    attachment do
+      blob_resource(AshStorage.SortTest.SortBlob)
+      belongs_to_resource(:sorted_post, AshStorage.SortTest.SortedPost)
+      belongs_to_resource(:do_block_sorted_post, AshStorage.SortTest.DoBlockSortedPost)
+      belongs_to_resource(:unsorted_post, AshStorage.SortTest.UnsortedPost)
+    end
+
+    attributes do
+      uuid_primary_key :id
+    end
+  end
+
+  defmodule SortedPost do
+    @moduledoc false
+    use Ash.Resource,
+      domain: AshStorage.SortTest.SortDomain,
+      data_layer: Ash.DataLayer.Ets,
+      extensions: [AshStorage]
+
+    ets do
+      private? true
+    end
+
+    storage do
+      service({AshStorage.Service.Test, []})
+      blob_resource(AshStorage.SortTest.SortBlob)
+      attachment_resource(AshStorage.SortTest.SortAttachment)
+
+      has_many_attached :documents, sort: [{:blob_id, :asc}]
+    end
+
+    attributes do
+      uuid_primary_key :id
+      attribute :title, :string, allow_nil?: false
+    end
+
+    actions do
+      defaults [:read, :destroy, create: [:title], update: [:title]]
+    end
+  end
+
+  defmodule DoBlockSortedPost do
+    @moduledoc false
+    use Ash.Resource,
+      domain: AshStorage.SortTest.SortDomain,
+      data_layer: Ash.DataLayer.Ets,
+      extensions: [AshStorage]
+
+    ets do
+      private? true
+    end
+
+    storage do
+      service({AshStorage.Service.Test, []})
+      blob_resource(AshStorage.SortTest.SortBlob)
+      attachment_resource(AshStorage.SortTest.SortAttachment)
+
+      has_many_attached :documents do
+        sort blob_id: :desc
+      end
+    end
+
+    attributes do
+      uuid_primary_key :id
+      attribute :title, :string, allow_nil?: false
+    end
+
+    actions do
+      defaults [:read, :destroy, create: [:title], update: [:title]]
+    end
+  end
+
+  defmodule UnsortedPost do
+    @moduledoc false
+    use Ash.Resource,
+      domain: AshStorage.SortTest.SortDomain,
+      data_layer: Ash.DataLayer.Ets,
+      extensions: [AshStorage]
+
+    ets do
+      private? true
+    end
+
+    storage do
+      service({AshStorage.Service.Test, []})
+      blob_resource(AshStorage.SortTest.SortBlob)
+      attachment_resource(AshStorage.SortTest.SortAttachment)
+
+      has_many_attached :documents
+    end
+
+    attributes do
+      uuid_primary_key :id
+      attribute :title, :string, allow_nil?: false
+    end
+
+    actions do
+      defaults [:read, :destroy, create: [:title], update: [:title]]
+    end
+  end
+
+  setup do
+    AshStorage.Service.Test.reset!()
+    :ok
+  end
+
+  describe "sort option on has_many_attached" do
+    test "relationship has sort when sort option is provided" do
+      rel = Ash.Resource.Info.relationship(SortedPost, :documents)
+      assert rel.sort == [{:blob_id, :asc}]
+    end
+
+    test "relationship has sort when sort is set in do block" do
+      rel = Ash.Resource.Info.relationship(DoBlockSortedPost, :documents)
+      assert rel.sort == [{:blob_id, :desc}]
+    end
+
+    test "relationship has no sort when sort option is omitted" do
+      rel = Ash.Resource.Info.relationship(UnsortedPost, :documents)
+      assert rel.sort == nil
+    end
+
+    test "loading returns attachments in sorted order" do
+      post =
+        SortedPost
+        |> Ash.Changeset.for_create(:create, %{title: "test"})
+        |> Ash.create!()
+
+      {:ok, _} = Operations.attach(post, :documents, "aaa", filename: "a.txt")
+      {:ok, _} = Operations.attach(post, :documents, "bbb", filename: "b.txt")
+      {:ok, _} = Operations.attach(post, :documents, "ccc", filename: "c.txt")
+
+      post = Ash.load!(post, :documents)
+      blob_ids = Enum.map(post.documents, & &1.blob_id)
+      assert blob_ids == Enum.sort(blob_ids)
+    end
+
+    test "sort can be overridden when loading" do
+      post =
+        SortedPost
+        |> Ash.Changeset.for_create(:create, %{title: "test"})
+        |> Ash.create!()
+
+      {:ok, _} = Operations.attach(post, :documents, "aaa", filename: "a.txt")
+      {:ok, _} = Operations.attach(post, :documents, "bbb", filename: "b.txt")
+      {:ok, _} = Operations.attach(post, :documents, "ccc", filename: "c.txt")
+
+      query = Ash.Query.sort(SortAttachment, blob_id: :desc)
+      post = Ash.load!(post, documents: query)
+      blob_ids = Enum.map(post.documents, & &1.blob_id)
+      assert blob_ids == Enum.sort(blob_ids, :desc)
+    end
+  end
+end


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [x] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

This PR allows passing default sort to `has_many_attached`.

Opening this now partially as a way to try and understand what is going on with CI failures in #12 (want to see if they happen here too).