### PR TITLE
feat: Add Azure blob support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,7 @@
 - Added `AshStorage.Service.AzureBlob` for Azure Blob Storage uploads, downloads, URLs, and direct uploads.
 - Added Azurite-backed live integration coverage for `AshStorage.Service.AzureBlob`.
 - Documented Azure SAS/CORS requirements and avoided persisting literal Azure credentials on blob records.
+
+### Changed
+
+- `AshStorage.Service.S3` now treats an empty string `:prefix` the same as `nil` (no prefix applied), matching `AshStorage.Service.AzureBlob`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,6 @@
 ### Added
 
 - Initial project setup
+- Added `AshStorage.Service.AzureBlob` for Azure Blob Storage uploads, downloads, URLs, and direct uploads.
+- Added Azurite-backed live integration coverage for `AshStorage.Service.AzureBlob`.
+- Documented Azure SAS/CORS requirements and avoided persisting literal Azure credentials on blob records.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,3 @@
 ### Added
 
 - Initial project setup
-- Added `AshStorage.Service.AzureBlob` for Azure Blob Storage uploads, downloads, URLs, and direct uploads.
-- Added Azurite-backed live integration coverage for `AshStorage.Service.AzureBlob`.
-- Documented Azure SAS/CORS requirements and avoided persisting literal Azure credentials on blob records.
-
-### Changed
-
-- `AshStorage.Service.S3` now treats an empty string `:prefix` the same as `nil` (no prefix applied), matching `AshStorage.Service.AzureBlob`.

--- a/README.md
+++ b/README.md
@@ -275,8 +275,20 @@ AshStorage ships with:
 - `AshStorage.Service.Disk` — Local filesystem storage
 - `AshStorage.Service.Test` — In-memory storage for tests
 - `AshStorage.Service.S3` — S3-compatible storage (requires [`req_s3`](https://hex.pm/packages/req_s3))
+- `AshStorage.Service.AzureBlob` — Azure Blob Storage (requires [`req`](https://hex.pm/packages/req))
 
 Implement the `AshStorage.Service` behaviour to add custom backends.
+
+### Live service integration tests
+
+External service integration tests are excluded from normal `mix test` runs:
+
+```bash
+mix test --include s3_integration test/ash_storage/service/s3_integration_test.exs
+mix test --include azure_integration test/ash_storage/service/azure_blob_integration_test.exs
+```
+
+The S3 suite starts MinIO with Docker. The Azure suite starts Azurite with Docker. Disk and Test service coverage run as part of the normal test suite.
 
 ## Roadmap
 
@@ -288,10 +300,16 @@ Implement the `AshStorage.Service` behaviour to add custom backends.
 - **Mirroring** — Mirror service that replicates uploads across multiple backends for redundancy
 - **Orphan cleanup** — Periodic cleanup of blobs without files or files without blobs. With AshOban: scheduled job. Without: manual invocation via `AshStorage.Operations.cleanup_orphans/1`.
 
+### Azure Blob Storage follow-ups
+
+- **Managed Identity / Azure AD** — Add OAuth-based requests and user delegation SAS generation for environments that disable shared key access.
+- **Block uploads** — Support `Put Block` / `Put Block List` for very large files and resumable direct uploads.
+- **Checksum verification** — Wire Azure `Content-MD5` / `x-ms-blob-content-md5` support into the broader checksum roadmap.
+- **CI integration** — Run the Azurite-backed `:azure_integration` suite in CI when Docker is available.
+
 ### Future services
 
 - **GCS** — Google Cloud Storage backend
-- **Azure** — Azure Blob Storage backend
 
 ### Library options under consideration
 

--- a/documentation/topics/direct-uploads.md
+++ b/documentation/topics/direct-uploads.md
@@ -108,6 +108,8 @@ service {AshStorage.Service.S3,
   direct_upload_method: :post}
 ```
 
+The JS example below is for presigned PUT. For presigned POST, build a `FormData` with the returned `:fields` (each as a form field), append the file last, and `POST` it as `multipart/form-data` — do not set `Content-Type` manually or send the raw file as the body.
+
 ## Step 2: Client uploads and attaches
 
 Send the presigned URL and blob ID to your client. The client uploads directly to storage, then includes the blob ID in a normal create or update:

--- a/documentation/topics/direct-uploads.md
+++ b/documentation/topics/direct-uploads.md
@@ -1,6 +1,6 @@
 # Direct Uploads
 
-Direct uploads let clients upload files straight to your storage backend (S3, MinIO, etc.) without proxying through your server. This is the recommended approach for large files — it keeps your application server out of the data path.
+Direct uploads let clients upload files straight to your storage backend (S3, MinIO, Azure Blob Storage, etc.) without proxying through your server. This is the recommended approach for large files — it keeps your application server out of the data path.
 
 The flow has two steps:
 
@@ -9,7 +9,7 @@ The flow has two steps:
 
 ## Setup
 
-Direct uploads require a storage service that supports presigned URLs. `AshStorage.Service.S3` supports this out of the box:
+Direct uploads require a storage service that supports presigned URLs. `AshStorage.Service.S3` and `AshStorage.Service.AzureBlob` support this out of the box:
 
 ```elixir
 storage do
@@ -24,6 +24,32 @@ storage do
   has_one_attached :cover_image
 end
 ```
+
+For Azure Blob Storage:
+
+```elixir
+storage do
+  service {AshStorage.Service.AzureBlob,
+    account: "myaccount",
+    container: "uploads",
+    account_key_env: "AZURE_STORAGE_ACCOUNT_KEY",
+    presigned: true}
+
+  blob_resource MyApp.StorageBlob
+  attachment_resource MyApp.StorageAttachment
+
+  has_one_attached :cover_image
+end
+```
+
+Azure browser uploads require CORS on the storage account and the `x-ms-blob-type: BlockBlob` request header. `AshStorage.Service.AzureBlob.direct_upload/2` includes that header in the returned upload info.
+
+Azure-specific checklist:
+
+- Create the blob container before uploads begin; the service creates blobs, not containers.
+- Configure Blob service CORS for your browser origin, `PUT`/`OPTIONS`, and the request headers your client sends, including `x-ms-blob-type` and `content-type`.
+- Prefer `:account_key_env` or `:sas_token_env` over literal secrets. Literal `:account_key` and `:sas_token` values work for immediate service requests but are not persisted on blob records. Use env-backed credentials for attachment flows that later operate from stored blobs, including purge, analysis, and variants.
+- If you provide a static SAS token via `:sas_token`/`:sas_token_env`, it is reused for every Azure operation. Use a container/account SAS with the needed permissions: read (`r`) for URLs/downloads/existence checks, create/write (`c`, `w`) for uploads/direct uploads, and delete (`d`) for purges.
 
 Add the `AshStorage.Changes.AttachBlob` change to your create or update actions:
 
@@ -68,6 +94,7 @@ The returned map contains:
 - `:blob` — the created blob record (not yet attached to anything)
 - `:url` — the presigned URL to upload to
 - `:method` — `:put` or `:post` depending on configuration
+- `:headers` — headers to include with the direct upload, when required by the service
 
 For S3 presigned POST (multipart form uploads), you also get `:fields` — a list of form fields to include.
 
@@ -86,11 +113,14 @@ service {AshStorage.Service.S3,
 Send the presigned URL and blob ID to your client. The client uploads directly to storage, then includes the blob ID in a normal create or update:
 
 ```javascript
-// 1. Upload directly to S3
-await fetch(presignedUrl, {
-  method: "PUT",
+// 1. Upload directly to storage
+const uploadHeaders = new Headers(prepareResponse.headers || {});
+uploadHeaders.set("Content-Type", file.type);
+
+await fetch(prepareResponse.url, {
+  method: prepareResponse.method || "PUT",
   body: file,
-  headers: { "Content-Type": file.type }
+  headers: uploadHeaders
 });
 
 // 2. Create the record with the blob attached
@@ -119,7 +149,13 @@ defmodule MyAppWeb.PostLive.Upload do
         byte_size: size
       )
 
-    {:reply, %{url: info.url, method: info.method, blob_id: info.blob.id}, socket}
+    {:reply,
+     %{
+       url: info.url,
+       method: info.method,
+       headers: Map.get(info, :headers, %{}),
+       blob_id: info.blob.id
+     }, socket}
   end
 
   def handle_event("create_post", %{"title" => title, "blob_id" => blob_id}, socket) do
@@ -188,8 +224,14 @@ defmodule MyApp.Post do
           byte_size: input.arguments.byte_size
         )
         |> case do
-          {:ok, %{blob: blob, url: url, method: method}} ->
-            {:ok, %{blob_id: blob.id, url: url, method: to_string(method)}}
+          {:ok, %{blob: blob, url: url, method: method} = info} ->
+            {:ok,
+             %{
+               blob_id: blob.id,
+               url: url,
+               method: to_string(method),
+               headers: Map.get(info, :headers, %{})
+             }}
 
           {:error, error} ->
             {:error, error}
@@ -213,8 +255,8 @@ end
 
 The client flow:
 
-1. `POST /posts/prepare_cover_image_upload` with `{"filename": "photo.jpg"}` — returns `{"blob_id": "...", "url": "https://s3...", "method": "PUT"}`
-2. `PUT` the file directly to the presigned S3 URL
+1. `POST /posts/prepare_cover_image_upload` with `{"filename": "photo.jpg"}` — returns `{"blob_id": "...", "url": "https://...", "method": "PUT", "headers": {}}`
+2. `PUT` the file directly to the presigned storage URL with any returned headers
 3. `POST /posts` with `{"title": "My Post", "cover_image_blob_id": "..."}` — creates the post with the image attached
 
 ## AshGraphql
@@ -257,6 +299,7 @@ mutation {
       blobId
       url
       method
+      headers
     }
   }
 }

--- a/lib/ash_storage/service/azure_blob.ex
+++ b/lib/ash_storage/service/azure_blob.ex
@@ -203,14 +203,54 @@ if Code.ensure_loaded?(Req) do
 
       case resolve_sas_token(ctx.service_opts) do
         {:ok, token} ->
-          {:ok, append_query(base_url, token)}
+          with :ok <- check_sas_permissions(token, Keyword.get(opts, :permissions)) do
+            {:ok, append_query(base_url, token)}
+          end
 
         :error ->
-          generate_sas_query(key, ctx, opts)
-          |> case do
+          case generate_sas_query(key, ctx, opts) do
             {:ok, query} -> {:ok, append_query(base_url, query)}
             {:error, reason} -> {:error, reason}
           end
+      end
+    end
+
+    # A configured SAS token is reused for every operation, so it must already
+    # grant the permissions each operation needs. Parse the `sp` field and fail
+    # fast when a required permission is missing. When the token has no `sp`
+    # parameter, fall through and let Azure return its own error.
+    defp check_sas_permissions(_token, nil), do: :ok
+    defp check_sas_permissions(_token, ""), do: :ok
+
+    defp check_sas_permissions(token, required) do
+      case sas_granted_permissions(token) do
+        {:ok, granted} ->
+          missing =
+            required
+            |> String.graphemes()
+            |> Enum.uniq()
+            |> Enum.reject(&String.contains?(granted, &1))
+
+          case missing do
+            [] ->
+              :ok
+
+            _ ->
+              {:error,
+               {:sas_missing_permissions,
+                required: required, granted: granted, missing: Enum.join(missing)}}
+          end
+
+        :error ->
+          :ok
+      end
+    end
+
+    defp sas_granted_permissions(token) do
+      case token |> URI.decode_query() |> Map.get("sp") do
+        nil -> :error
+        "" -> :error
+        sp -> {:ok, sp}
       end
     end
 

--- a/lib/ash_storage/service/azure_blob.ex
+++ b/lib/ash_storage/service/azure_blob.ex
@@ -1,0 +1,452 @@
+if Code.ensure_loaded?(Req) do
+  defmodule AshStorage.Service.AzureBlob do
+    @moduledoc """
+    A storage service for Azure Blob Storage.
+
+    Uses `Req` and Azure Blob Storage SAS URLs for HTTP operations. The service can
+    either append a configured SAS token or generate short-lived per-blob SAS tokens
+    from an account key.
+
+    ## Configuration
+
+        storage do
+          service {AshStorage.Service.AzureBlob,
+            account: "myaccount",
+            container: "uploads",
+            account_key_env: "AZURE_STORAGE_ACCOUNT_KEY",
+            presigned: true}
+        end
+
+    Prefer `:account_key_env` or `:sas_token_env` over literal secrets. Raw
+    `:account_key` and `:sas_token` values are accepted for immediate service
+    calls, but are intentionally not persisted on blob records. Use env-backed
+    credentials for attachment flows that later operate from stored blob records,
+    such as purge, analysis, and variants.
+
+    ## Options
+
+    - `:account` - (required) the Azure Storage account name
+    - `:container` - (required) the blob container name
+    - `:account_key` - base64-encoded storage account key. Falls back to the
+      `AZURE_STORAGE_ACCOUNT_KEY` environment variable. Not persisted on blob
+      records; use `:account_key_env` for purge/analysis/variants
+    - `:account_key_env` - environment variable to read the account key from
+      (default: `"AZURE_STORAGE_ACCOUNT_KEY"`)
+    - `:sas_token` - pre-generated SAS token to append to requests. Falls back to
+      the `AZURE_STORAGE_SAS_TOKEN` environment variable. Not persisted on blob
+      records; use `:sas_token_env` for purge/analysis/variants
+    - `:sas_token_env` - environment variable to read the SAS token from
+      (default: `"AZURE_STORAGE_SAS_TOKEN"`)
+    - `:endpoint_url` - custom endpoint URL. Useful for Azurite, e.g.
+      `"http://127.0.0.1:10000/devstoreaccount1"`
+    - `:prefix` - optional key prefix (e.g. `"uploads/"`)
+    - `:presigned` - when `true`, `url/2` returns a read SAS URL. Otherwise it
+      returns the unsigned/public blob URL
+    - `:expires_in` - default SAS expiration for `url/2`, in seconds (default: `3600`)
+    - `:direct_upload_expires_in` - SAS expiration for direct uploads, in seconds
+      (default: `900`)
+    - `:service_version` - Azure Storage service version for SAS generation
+      (default: `"2020-12-06"`)
+    - `:signed_protocol` - SAS protocol restriction. Defaults to `"https"`, or
+      `"https,http"` for `http://` endpoints
+
+    ## Azure setup
+
+    Create a StorageV2 account and a private blob container. For account-key SAS
+    generation, make a storage account key available to the application, preferably
+    through `:account_key_env`. Alternatively, configure a pre-generated container
+    or account SAS through `:sas_token_env`.
+
+    Configured SAS tokens are reused for every operation. They must be scoped to
+    the target container/account and include the permissions needed by each flow:
+    read (`r`) for downloads/URLs/existence checks, create/write (`c`, `w`) for
+    uploads and direct uploads, and delete (`d`) for purge/delete.
+
+    For browser direct uploads, configure CORS on the storage account to allow your
+    application origin, the `PUT`/`OPTIONS` methods, and the request headers your
+    client sends, including `x-ms-blob-type` and `content-type`.
+
+    This service uses Azure's single `Put Blob` operation for uploads. Very large
+    multi-block uploads (`Put Block`/`Put Block List`) are not implemented yet.
+    """
+
+    @behaviour AshStorage.Service
+
+    @default_account_key_env "AZURE_STORAGE_ACCOUNT_KEY"
+    @default_sas_token_env "AZURE_STORAGE_SAS_TOKEN"
+    @default_service_version "2020-12-06"
+
+    @impl true
+    def service_opts_fields do
+      [
+        account: [type: :string, allow_nil?: false],
+        container: [type: :string, allow_nil?: false],
+        endpoint_url: [type: :string],
+        prefix: [type: :string],
+        account_key_env: [type: :string],
+        sas_token_env: [type: :string],
+        presigned: [type: :boolean],
+        service_version: [type: :string],
+        signed_protocol: [type: :string]
+      ]
+    end
+
+    @impl true
+    def upload(key, data, %AshStorage.Service.Context{} = ctx) do
+      full_key = prefixed_key(key, ctx)
+
+      with {:ok, url} <- signed_blob_url(full_key, ctx, permissions: "cw", expires_in: 900) do
+        headers =
+          ctx
+          |> base_headers()
+          |> Map.put("x-ms-blob-type", "BlockBlob")
+          |> maybe_put_header("content-type", Keyword.get(ctx.service_opts, :content_type))
+
+        case Req.put(url, body: data, headers: headers) do
+          {:ok, %{status: status}} when status in 200..299 -> :ok
+          {:ok, %{status: status, body: body}} -> {:error, {status, body}}
+          {:error, reason} -> {:error, reason}
+        end
+      end
+    end
+
+    @impl true
+    def download(key, %AshStorage.Service.Context{} = ctx) do
+      full_key = prefixed_key(key, ctx)
+
+      with {:ok, url} <- signed_blob_url(full_key, ctx, permissions: "r", expires_in: 900) do
+        case Req.get(url, headers: base_headers(ctx)) do
+          {:ok, %{status: 200, body: body}} -> {:ok, body}
+          {:ok, %{status: 404}} -> {:error, :not_found}
+          {:ok, %{status: status, body: body}} -> {:error, {status, body}}
+          {:error, reason} -> {:error, reason}
+        end
+      end
+    end
+
+    @impl true
+    def delete(key, %AshStorage.Service.Context{} = ctx) do
+      full_key = prefixed_key(key, ctx)
+
+      with {:ok, url} <- signed_blob_url(full_key, ctx, permissions: "d", expires_in: 900) do
+        case Req.delete(url, headers: base_headers(ctx)) do
+          {:ok, %{status: status}} when status in [200, 202, 204] -> :ok
+          {:ok, %{status: 404}} -> :ok
+          {:ok, %{status: status, body: body}} -> {:error, {status, body}}
+          {:error, reason} -> {:error, reason}
+        end
+      end
+    end
+
+    @impl true
+    def exists?(key, %AshStorage.Service.Context{} = ctx) do
+      full_key = prefixed_key(key, ctx)
+
+      with {:ok, url} <- signed_blob_url(full_key, ctx, permissions: "r", expires_in: 900) do
+        case Req.head(url, headers: base_headers(ctx)) do
+          {:ok, %{status: 200}} -> {:ok, true}
+          {:ok, %{status: 404}} -> {:ok, false}
+          {:ok, %{status: status}} -> {:error, {:unexpected_status, status}}
+          {:error, reason} -> {:error, reason}
+        end
+      end
+    end
+
+    @impl true
+    def url(key, %AshStorage.Service.Context{} = ctx) do
+      full_key = prefixed_key(key, ctx)
+
+      if Keyword.get(ctx.service_opts, :presigned, false) do
+        case signed_blob_url(full_key, ctx,
+               permissions: "r",
+               expires_in: Keyword.get(ctx.service_opts, :expires_in, 3600),
+               response_headers: response_headers(ctx.service_opts)
+             ) do
+          {:ok, url} ->
+            url
+
+          {:error, reason} ->
+            raise ArgumentError, "could not generate Azure Blob SAS URL: #{inspect(reason)}"
+        end
+      else
+        blob_url(full_key, ctx)
+      end
+    end
+
+    @doc """
+    Generate a presigned PUT URL for direct client-side upload.
+
+    Azure Blob Storage direct uploads require the `x-ms-blob-type: BlockBlob`
+    header. The returned map includes this header.
+    """
+    @impl true
+    def direct_upload(key, %AshStorage.Service.Context{} = ctx) do
+      full_key = prefixed_key(key, ctx)
+
+      with {:ok, url} <-
+             signed_blob_url(full_key, ctx,
+               permissions: "cw",
+               expires_in: Keyword.get(ctx.service_opts, :direct_upload_expires_in, 900)
+             ) do
+        headers =
+          %{"x-ms-blob-type" => "BlockBlob"}
+          |> maybe_put_header("content-type", Keyword.get(ctx.service_opts, :content_type))
+
+        {:ok, %{url: url, method: :put, headers: headers}}
+      end
+    end
+
+    # -- Private helpers --
+
+    defp signed_blob_url(key, %AshStorage.Service.Context{} = ctx, opts) do
+      base_url = blob_url(key, ctx)
+
+      case resolve_sas_token(ctx.service_opts) do
+        {:ok, token} ->
+          {:ok, append_query(base_url, token)}
+
+        :error ->
+          generate_sas_query(key, ctx, opts)
+          |> case do
+            {:ok, query} -> {:ok, append_query(base_url, query)}
+            {:error, reason} -> {:error, reason}
+          end
+      end
+    end
+
+    defp generate_sas_query(key, %AshStorage.Service.Context{} = ctx, opts) do
+      service_opts = ctx.service_opts
+      account = Keyword.fetch!(service_opts, :account)
+      container = Keyword.fetch!(service_opts, :container)
+
+      with {:ok, account_key} <- resolve_account_key(service_opts) do
+        permissions = Keyword.fetch!(opts, :permissions)
+        version = service_version(service_opts)
+        resource = Keyword.get(opts, :resource, "b")
+        start_time = opts |> Keyword.get(:starts_at) |> format_time()
+        expiry_time = opts |> expiry_time(service_opts) |> format_time()
+        protocol = signed_protocol(service_opts)
+        response_headers = Keyword.get(opts, :response_headers, %{})
+        canonicalized_resource = "/blob/#{account}/#{container}/#{key}"
+
+        string_to_sign =
+          [
+            permissions,
+            start_time,
+            expiry_time,
+            canonicalized_resource,
+            "",
+            "",
+            protocol,
+            version,
+            resource,
+            "",
+            "",
+            Map.get(response_headers, "rscc", ""),
+            Map.get(response_headers, "rscd", ""),
+            Map.get(response_headers, "rsce", ""),
+            Map.get(response_headers, "rscl", ""),
+            Map.get(response_headers, "rsct", "")
+          ]
+          |> Enum.join("\n")
+
+        signature =
+          :crypto.mac(:hmac, :sha256, account_key, string_to_sign)
+          |> Base.encode64()
+
+        query =
+          [
+            {"sv", version},
+            {"spr", protocol},
+            {"se", expiry_time},
+            {"sr", resource},
+            {"sp", permissions},
+            {"sig", signature}
+          ]
+          |> maybe_put_query("st", start_time)
+          |> put_response_header_params(response_headers)
+          |> URI.encode_query()
+
+        {:ok, query}
+      end
+    end
+
+    defp blob_url(key, %AshStorage.Service.Context{} = ctx) do
+      opts = ctx.service_opts
+      container = Keyword.fetch!(opts, :container)
+
+      "#{endpoint_url(opts)}/#{encode_path_segment(container)}/#{encode_blob_path(key)}"
+    end
+
+    defp endpoint_url(opts) do
+      account = Keyword.fetch!(opts, :account)
+
+      opts
+      |> Keyword.get(:endpoint_url, "https://#{account}.blob.core.windows.net")
+      |> String.trim_trailing("/")
+    end
+
+    defp prefixed_key(key, %AshStorage.Service.Context{} = ctx) do
+      case Keyword.get(ctx.service_opts, :prefix) do
+        nil -> key
+        "" -> key
+        prefix -> "#{prefix}#{key}"
+      end
+    end
+
+    defp base_headers(%AshStorage.Service.Context{} = ctx) do
+      %{"x-ms-version" => service_version(ctx.service_opts)}
+    end
+
+    defp service_version(opts) do
+      Keyword.get(opts, :service_version, @default_service_version)
+    end
+
+    defp signed_protocol(opts) do
+      Keyword.get(opts, :signed_protocol) ||
+        if String.starts_with?(endpoint_url(opts), "http://") do
+          "https,http"
+        else
+          "https"
+        end
+    end
+
+    defp resolve_account_key(opts) do
+      key =
+        Keyword.get(opts, :account_key) ||
+          opts
+          |> Keyword.get(:account_key_env, @default_account_key_env)
+          |> System.get_env()
+
+      case key do
+        nil ->
+          {:error, :missing_credentials}
+
+        "" ->
+          {:error, :missing_credentials}
+
+        key ->
+          case Base.decode64(key) do
+            {:ok, decoded} -> {:ok, decoded}
+            :error -> {:error, :invalid_account_key}
+          end
+      end
+    end
+
+    defp resolve_sas_token(opts) do
+      token =
+        Keyword.get(opts, :sas_token) ||
+          opts
+          |> Keyword.get(:sas_token_env, @default_sas_token_env)
+          |> System.get_env()
+
+      case token do
+        nil ->
+          :error
+
+        "" ->
+          :error
+
+        token ->
+          case normalize_sas_token(token) do
+            "" -> :error
+            token -> {:ok, token}
+          end
+      end
+    end
+
+    defp normalize_sas_token(token) do
+      token
+      |> String.trim()
+      |> String.trim_leading("?")
+    end
+
+    defp append_query(url, ""), do: url
+
+    defp append_query(url, query) do
+      separator = if String.contains?(url, "?"), do: "&", else: "?"
+      "#{url}#{separator}#{normalize_sas_token(query)}"
+    end
+
+    defp expiry_time(opts, service_opts) do
+      case Keyword.get(opts, :expires_at) do
+        nil ->
+          expires_in =
+            Keyword.get(opts, :expires_in, Keyword.get(service_opts, :expires_in, 3600))
+
+          DateTime.utc_now() |> DateTime.add(expires_in, :second)
+
+        expires_at ->
+          expires_at
+      end
+    end
+
+    defp format_time(nil), do: ""
+
+    defp format_time(%DateTime{} = datetime) do
+      datetime
+      |> DateTime.truncate(:second)
+      |> DateTime.to_iso8601()
+    end
+
+    defp format_time(%NaiveDateTime{} = datetime) do
+      datetime
+      |> DateTime.from_naive!("Etc/UTC")
+      |> format_time()
+    end
+
+    defp format_time(value) when is_binary(value), do: value
+
+    defp response_headers(opts) do
+      %{}
+      |> maybe_put_response_header("rscc", Keyword.get(opts, :cache_control))
+      |> maybe_put_response_header("rscd", content_disposition(opts))
+      |> maybe_put_response_header("rsce", Keyword.get(opts, :content_encoding))
+      |> maybe_put_response_header("rscl", Keyword.get(opts, :content_language))
+      |> maybe_put_response_header("rsct", Keyword.get(opts, :content_type))
+    end
+
+    defp content_disposition(opts) do
+      Keyword.get(opts, :content_disposition) ||
+        case Keyword.get(opts, :disposition) do
+          nil -> nil
+          disposition -> build_content_disposition(disposition, Keyword.get(opts, :filename))
+        end
+    end
+
+    defp build_content_disposition(disposition, nil), do: to_string(disposition)
+
+    defp build_content_disposition(disposition, filename) do
+      escaped_filename = filename |> to_string() |> String.replace("\"", "\\\"")
+      ~s(#{disposition}; filename="#{escaped_filename}")
+    end
+
+    defp put_response_header_params(query, response_headers) do
+      Enum.reduce(response_headers, query, fn {name, value}, acc ->
+        maybe_put_query(acc, name, value)
+      end)
+    end
+
+    defp maybe_put_query(query, _key, nil), do: query
+    defp maybe_put_query(query, _key, ""), do: query
+    defp maybe_put_query(query, key, value), do: query ++ [{key, value}]
+
+    defp maybe_put_response_header(headers, _key, nil), do: headers
+    defp maybe_put_response_header(headers, _key, ""), do: headers
+    defp maybe_put_response_header(headers, key, value), do: Map.put(headers, key, value)
+
+    defp maybe_put_header(headers, _key, nil), do: headers
+    defp maybe_put_header(headers, _key, ""), do: headers
+    defp maybe_put_header(headers, key, value), do: Map.put(headers, key, value)
+
+    defp encode_blob_path(key) do
+      key
+      |> String.split("/")
+      |> Enum.map_join("/", &encode_path_segment/1)
+    end
+
+    defp encode_path_segment(segment) do
+      URI.encode(segment, &URI.char_unreserved?/1)
+    end
+  end
+end

--- a/lib/ash_storage/service/azure_blob.ex
+++ b/lib/ash_storage/service/azure_blob.ex
@@ -66,8 +66,22 @@ if Code.ensure_loaded?(Req) do
     application origin, the `PUT`/`OPTIONS` methods, and the request headers your
     client sends, including `x-ms-blob-type` and `content-type`.
 
-    This service uses Azure's single `Put Blob` operation for uploads. Very large
-    multi-block uploads (`Put Block`/`Put Block List`) are not implemented yet.
+    ## Limits
+
+    Uploads use a single `Put Blob` request, which Azure caps at 5,000 MiB per
+    request and recommends keeping under 256 MiB. Block-based uploads
+    (`Put Block` / `Put Block List`) for larger or resumable uploads are tracked
+    on the roadmap.
+
+    ## Per-call Content-Type
+
+    `:content_type` listed below is read from `service_opts` (i.e. set on the
+    storage configuration), not from per-call attach or `prepare_direct_upload/3`
+    options. To pin a specific Content-Type to direct uploads from a single
+    attachment, configure the service for that attachment with `:content_type`
+    set. Browsers performing direct uploads typically set their own
+    `Content-Type` request header, so the SAS-signed override is only needed
+    when you want it pinned server-side.
     """
 
     @behaviour AshStorage.Service
@@ -86,6 +100,8 @@ if Code.ensure_loaded?(Req) do
         account_key_env: [type: :string],
         sas_token_env: [type: :string],
         presigned: [type: :boolean],
+        expires_in: [type: :integer],
+        direct_upload_expires_in: [type: :integer],
         service_version: [type: :string],
         signed_protocol: [type: :string]
       ]
@@ -95,12 +111,17 @@ if Code.ensure_loaded?(Req) do
     def upload(key, data, %AshStorage.Service.Context{} = ctx) do
       full_key = prefixed_key(key, ctx)
 
+      # Azure's `Put Blob` rejects Transfer-Encoding: chunked, which Req+Finch
+      # emit for any non-iodata body (including File.Stream). Materialise the
+      # stream so the request goes out with a fixed Content-Length.
+      data = materialize_body(data)
+
       with {:ok, url} <- signed_blob_url(full_key, ctx, permissions: "cw", expires_in: 900) do
         headers =
           ctx
           |> base_headers()
           |> Map.put("x-ms-blob-type", "BlockBlob")
-          |> maybe_put_header("content-type", Keyword.get(ctx.service_opts, :content_type))
+          |> maybe_put("content-type", Keyword.get(ctx.service_opts, :content_type))
 
         case Req.put(url, body: data, headers: headers) do
           {:ok, %{status: status}} when status in 200..299 -> :ok
@@ -190,13 +211,16 @@ if Code.ensure_loaded?(Req) do
              ) do
         headers =
           %{"x-ms-blob-type" => "BlockBlob"}
-          |> maybe_put_header("content-type", Keyword.get(ctx.service_opts, :content_type))
+          |> maybe_put("content-type", Keyword.get(ctx.service_opts, :content_type))
 
         {:ok, %{url: url, method: :put, headers: headers}}
       end
     end
 
     # -- Private helpers --
+
+    defp materialize_body(%File.Stream{path: path}), do: File.read!(path)
+    defp materialize_body(data) when is_binary(data) or is_list(data), do: data
 
     defp signed_blob_url(key, %AshStorage.Service.Context{} = ctx, opts) do
       base_url = blob_url(key, ctx)
@@ -295,15 +319,15 @@ if Code.ensure_loaded?(Req) do
           |> Base.encode64()
 
         query =
-          [
-            {"sv", version},
-            {"spr", protocol},
-            {"se", expiry_time},
-            {"sr", resource},
-            {"sp", permissions},
-            {"sig", signature}
-          ]
-          |> maybe_put_query("st", start_time)
+          %{
+            "sv" => version,
+            "spr" => protocol,
+            "se" => expiry_time,
+            "sr" => resource,
+            "sp" => permissions,
+            "sig" => signature
+          }
+          |> maybe_put("st", start_time)
           |> put_response_header_params(response_headers)
           |> URI.encode_query()
 
@@ -439,11 +463,11 @@ if Code.ensure_loaded?(Req) do
 
     defp response_headers(opts) do
       %{}
-      |> maybe_put_response_header("rscc", Keyword.get(opts, :cache_control))
-      |> maybe_put_response_header("rscd", content_disposition(opts))
-      |> maybe_put_response_header("rsce", Keyword.get(opts, :content_encoding))
-      |> maybe_put_response_header("rscl", Keyword.get(opts, :content_language))
-      |> maybe_put_response_header("rsct", Keyword.get(opts, :content_type))
+      |> maybe_put("rscc", Keyword.get(opts, :cache_control))
+      |> maybe_put("rscd", content_disposition(opts))
+      |> maybe_put("rsce", Keyword.get(opts, :content_encoding))
+      |> maybe_put("rscl", Keyword.get(opts, :content_language))
+      |> maybe_put("rsct", Keyword.get(opts, :content_type))
     end
 
     defp content_disposition(opts) do
@@ -463,21 +487,13 @@ if Code.ensure_loaded?(Req) do
 
     defp put_response_header_params(query, response_headers) do
       Enum.reduce(response_headers, query, fn {name, value}, acc ->
-        maybe_put_query(acc, name, value)
+        maybe_put(acc, name, value)
       end)
     end
 
-    defp maybe_put_query(query, _key, nil), do: query
-    defp maybe_put_query(query, _key, ""), do: query
-    defp maybe_put_query(query, key, value), do: query ++ [{key, value}]
-
-    defp maybe_put_response_header(headers, _key, nil), do: headers
-    defp maybe_put_response_header(headers, _key, ""), do: headers
-    defp maybe_put_response_header(headers, key, value), do: Map.put(headers, key, value)
-
-    defp maybe_put_header(headers, _key, nil), do: headers
-    defp maybe_put_header(headers, _key, ""), do: headers
-    defp maybe_put_header(headers, key, value), do: Map.put(headers, key, value)
+    defp maybe_put(collection, _key, nil), do: collection
+    defp maybe_put(collection, _key, ""), do: collection
+    defp maybe_put(collection, key, value), do: Map.put(collection, key, value)
 
     defp encode_blob_path(key) do
       key

--- a/lib/ash_storage/service/s3.ex
+++ b/lib/ash_storage/service/s3.ex
@@ -125,6 +125,11 @@ if Code.ensure_loaded?(ReqS3) do
 
     For `:put`, returns `%{url: presigned_url, method: :put}`.
     For `:post`, returns `%{url: form_url, method: :post, fields: [...]}`.
+
+    Note: this currently returns no `:headers`. If you add request headers that
+    SigV4 signs (any `x-amz-*` header, e.g. SSE or `x-amz-meta-*`), they must be
+    included at presign time — clients sending them post-hoc will get a signature
+    mismatch.
     """
     @impl true
     def direct_upload(key, %AshStorage.Service.Context{} = ctx) do

--- a/lib/ash_storage/service/s3.ex
+++ b/lib/ash_storage/service/s3.ex
@@ -197,6 +197,7 @@ if Code.ensure_loaded?(ReqS3) do
     defp prefixed_key(key, %AshStorage.Service.Context{} = ctx) do
       case Keyword.get(ctx.service_opts, :prefix) do
         nil -> key
+        "" -> key
         prefix -> "#{prefix}#{key}"
       end
     end

--- a/mix.exs
+++ b/mix.exs
@@ -97,6 +97,7 @@ defmodule AshStorage.MixProject do
         ],
         Services: [
           AshStorage.Service,
+          AshStorage.Service.AzureBlob,
           AshStorage.Service.Disk,
           AshStorage.Service.S3,
           AshStorage.Service.Test

--- a/test/ash_storage/service/azure_blob_integration_test.exs
+++ b/test/ash_storage/service/azure_blob_integration_test.exs
@@ -194,13 +194,13 @@ defmodule AshStorage.Service.AzureBlobIntegrationTest do
 
   describe "configured SAS tokens" do
     test "work for all operations when the token has the required permissions" do
+      key = unique_key()
+
       sas_ctx =
         @service_opts
         |> Keyword.put(:account_key_env, "MISSING_AZURE_STORAGE_ACCOUNT_KEY")
-        |> Keyword.put(:sas_token, account_sas_token())
+        |> Keyword.put(:sas_token, blob_sas_token(key, "rcwd"))
         |> Context.new()
-
-      key = unique_key()
 
       assert :ok = AzureBlob.upload(key, "sas token content", sas_ctx)
       assert {:ok, true} = AzureBlob.exists?(key, sas_ctx)
@@ -287,6 +287,63 @@ defmodule AshStorage.Service.AzureBlobIntegrationTest do
       Application.delete_env(:ash_storage, AshStorage.Test.ConfigurablePost)
     end
 
+    test "literal :account_key is not persisted on blob records, breaking async flows" do
+      # Regression test for the documented gotcha: literal :account_key works for
+      # the immediate request path because the live context has it, but the credential
+      # is intentionally excluded from service_opts_fields. Async/blob-driven flows
+      # rebuild the context from blob.parsed_service_opts and must therefore fall
+      # back to env-backed credentials. Pointing :account_key_env at a deliberately
+      # missing env var proves the literal credential never reaches that code path.
+      missing_env = "MISSING_AZURE_KEY_FOR_TEST_#{System.unique_integer([:positive])}"
+      System.delete_env(missing_env)
+
+      literal_opts =
+        @service_opts
+        |> Keyword.delete(:account_key_env)
+        |> Keyword.put(:account_key, @account_key)
+        |> Keyword.put(:account_key_env, missing_env)
+
+      Application.put_env(:ash_storage, AshStorage.Test.ConfigurablePost,
+        storage: [
+          service: {AshStorage.Service.AzureBlob, literal_opts}
+        ]
+      )
+
+      post =
+        AshStorage.Test.ConfigurablePost
+        |> Ash.Changeset.for_create(:create, %{title: "literal cred post"})
+        |> Ash.create!()
+
+      # Attach succeeds — the live changeset context carries the literal account key.
+      {:ok, %{blob: blob}} =
+        AshStorage.Operations.attach(post, :avatar, "literal cred content",
+          filename: "literal.txt",
+          content_type: "text/plain"
+        )
+
+      assert {:ok, "literal cred content"} = AzureBlob.download(blob.key, ctx())
+
+      # The persisted map only contains fields declared in service_opts_fields/0.
+      stored_opts = blob.service_opts || %{}
+      refute Map.has_key?(stored_opts, :account_key)
+      refute Map.has_key?(stored_opts, "account_key")
+
+      # parsed_service_opts is what async/blob-driven flows rebuild a context from.
+      blob = Ash.load!(blob, :parsed_service_opts)
+      parsed = blob.parsed_service_opts || []
+      refute Keyword.has_key?(parsed, :account_key)
+
+      # Calling :purge_blob directly drives the same code path AshOban would.
+      # Without an env-backed credential it cannot resolve the account key.
+      assert {:error, error} = Ash.destroy(blob, action: :purge_blob, return_destroyed?: true)
+      assert Exception.message(error) =~ "missing_credentials"
+
+      # The file is still in storage — clean it up via the env-backed test context.
+      assert :ok = AzureBlob.delete(blob.key, ctx())
+    after
+      Application.delete_env(:ash_storage, AshStorage.Test.ConfigurablePost)
+    end
+
     test "direct upload flow via Azure Blob Storage" do
       Application.put_env(:ash_storage, AshStorage.Test.ConfigurablePost,
         storage: [
@@ -361,9 +418,9 @@ defmodule AshStorage.Service.AzureBlobIntegrationTest do
   defp create_container(0), do: {:error, :timeout}
 
   defp create_container(attempts) do
-    url = "#{@endpoint_url}/#{@container}?restype=container&#{account_sas_token()}"
+    url = "#{@endpoint_url}/#{@container}?restype=container"
 
-    case Req.put(url, headers: %{"x-ms-version" => @service_version}, body: "") do
+    case Req.put(url, headers: shared_key_headers(), body: "") do
       {:ok, %{status: status}} when status in [201, 202, 409] ->
         :ok
 
@@ -373,24 +430,67 @@ defmodule AshStorage.Service.AzureBlobIntegrationTest do
     end
   end
 
-  defp account_sas_token do
-    permissions = "rwdlacup"
-    services = "b"
-    resource_types = "sco"
-    protocol = "https,http"
-    expiry_time = DateTime.utc_now() |> DateTime.add(3600, :second) |> format_time()
+  defp shared_key_headers do
+    date = Calendar.strftime(DateTime.utc_now(), "%a, %d %b %Y %H:%M:%S GMT")
+
+    canonicalized_headers =
+      "x-ms-date:#{date}\nx-ms-version:#{@service_version}\n"
+
+    # Azurite uses path-style URLs, so the account appears both as the signing
+    # account and as the first path segment.
+    canonicalized_resource = "/#{@account}/#{@account}/#{@container}\nrestype:container"
 
     string_to_sign =
       [
-        @account,
+        "PUT",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        canonicalized_headers <> canonicalized_resource
+      ]
+      |> Enum.join("\n")
+
+    signature =
+      :crypto.mac(:hmac, :sha256, Base.decode64!(@account_key), string_to_sign)
+      |> Base.encode64()
+
+    %{
+      "authorization" => "SharedKey #{@account}:#{signature}",
+      "x-ms-date" => date,
+      "x-ms-version" => @service_version
+    }
+  end
+
+  defp blob_sas_token(key, permissions) do
+    protocol = "https,http"
+    expiry_time = DateTime.utc_now() |> DateTime.add(3600, :second) |> format_time()
+    canonicalized_resource = "/blob/#{@account}/#{@container}/#{key}"
+
+    string_to_sign =
+      [
         permissions,
-        services,
-        resource_types,
         "",
         expiry_time,
+        canonicalized_resource,
+        "",
         "",
         protocol,
         @service_version,
+        "b",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
         ""
       ]
       |> Enum.join("\n")
@@ -401,11 +501,10 @@ defmodule AshStorage.Service.AzureBlobIntegrationTest do
 
     [
       {"sv", @service_version},
-      {"ss", services},
-      {"srt", resource_types},
-      {"sp", permissions},
-      {"se", expiry_time},
       {"spr", protocol},
+      {"se", expiry_time},
+      {"sr", "b"},
+      {"sp", permissions},
       {"sig", signature}
     ]
     |> URI.encode_query()

--- a/test/ash_storage/service/azure_blob_integration_test.exs
+++ b/test/ash_storage/service/azure_blob_integration_test.exs
@@ -117,6 +117,27 @@ defmodule AshStorage.Service.AzureBlobIntegrationTest do
       assert {:ok, ^data} = AzureBlob.download(key, ctx())
     end
 
+    test "round-trips a File.Stream" do
+      key = unique_key()
+      data = :crypto.strong_rand_bytes(64 * 1024)
+
+      path =
+        Path.join(
+          System.tmp_dir!(),
+          "ash_storage_azure_filestream_#{System.unique_integer([:positive])}.bin"
+        )
+
+      File.write!(path, data)
+
+      try do
+        stream = File.stream!(path, 8192)
+        assert :ok = AzureBlob.upload(key, stream, ctx())
+        assert {:ok, ^data} = AzureBlob.download(key, ctx())
+      after
+        File.rm(path)
+      end
+    end
+
     test "download returns not_found for missing key" do
       assert {:error, :not_found} = AzureBlob.download(unique_key(), ctx())
     end
@@ -177,6 +198,47 @@ defmodule AshStorage.Service.AzureBlobIntegrationTest do
       assert params["se"]
       assert {:ok, %{status: 200, body: "expiry test"}} = Req.get(url)
     end
+
+    test "expires_in survives a context rebuilt from blob.parsed_service_opts" do
+      # Async/blob-driven flows (custom URL calcs operating on a stored blob,
+      # background workers, etc.) reconstruct the service context from
+      # blob.parsed_service_opts. A documented service option that silently
+      # falls back to defaults in that path is a footgun: the user configures
+      # `expires_in: 120` in the DSL and gets 3600s SAS URLs in async code.
+      Application.put_env(:ash_storage, AshStorage.Test.ConfigurablePost,
+        storage: [
+          service:
+            {AshStorage.Service.AzureBlob,
+             @service_opts |> Keyword.put(:presigned, true) |> Keyword.put(:expires_in, 120)}
+        ]
+      )
+
+      AshStorage.Service.Test.reset!()
+
+      post =
+        AshStorage.Test.ConfigurablePost
+        |> Ash.Changeset.for_create(:create, %{title: "expires_in persistence"})
+        |> Ash.create!()
+
+      {:ok, %{blob: blob}} =
+        AshStorage.Operations.attach(post, :avatar, "expires content",
+          filename: "expires.txt",
+          content_type: "text/plain"
+        )
+
+      blob = Ash.load!(blob, :parsed_service_opts)
+      ctx = Context.new(blob.parsed_service_opts || [])
+      url = AzureBlob.url(blob.key, ctx)
+
+      params = url |> URI.parse() |> Map.fetch!(:query) |> URI.decode_query()
+      {:ok, expires_at, _} = DateTime.from_iso8601(params["se"])
+      diff = DateTime.diff(expires_at, DateTime.utc_now(), :second)
+
+      assert diff in 60..240,
+             "expected SAS expiry ~120s away, got #{diff}s — :expires_in did not survive parsed_service_opts"
+    after
+      Application.delete_env(:ash_storage, AshStorage.Test.ConfigurablePost)
+    end
   end
 
   describe "prefix option" do
@@ -207,6 +269,76 @@ defmodule AshStorage.Service.AzureBlobIntegrationTest do
       assert {:ok, "sas token content"} = AzureBlob.download(key, sas_ctx)
       assert :ok = AzureBlob.delete(key, sas_ctx)
       assert {:ok, false} = AzureBlob.exists?(key, sas_ctx)
+    end
+  end
+
+  describe "Proxy plug with Azure Blob" do
+    test "serves file through proxy" do
+      key = unique_key()
+      AzureBlob.upload(key, "proxy azure content", ctx())
+
+      plug_opts =
+        AshStorage.Plug.Proxy.init(service: {AshStorage.Service.AzureBlob, @service_opts})
+
+      conn =
+        Plug.Test.conn(:get, "/#{key}")
+        |> AshStorage.Plug.Proxy.call(plug_opts)
+
+      assert conn.status == 200
+      assert conn.resp_body == "proxy azure content"
+    end
+
+    test "returns 404 for missing key through proxy" do
+      plug_opts =
+        AshStorage.Plug.Proxy.init(service: {AshStorage.Service.AzureBlob, @service_opts})
+
+      conn =
+        Plug.Test.conn(:get, "/#{unique_key()}")
+        |> AshStorage.Plug.Proxy.call(plug_opts)
+
+      assert conn.status == 404
+    end
+
+    test "signed proxy rejects unsigned requests" do
+      key = unique_key()
+      AzureBlob.upload(key, "secret data", ctx())
+
+      plug_opts =
+        AshStorage.Plug.Proxy.init(
+          service: {AshStorage.Service.AzureBlob, @service_opts},
+          secret: "proxy-test-secret"
+        )
+
+      conn =
+        Plug.Test.conn(:get, "/#{key}")
+        |> AshStorage.Plug.Proxy.call(plug_opts)
+
+      assert conn.status == 403
+    end
+
+    test "signed proxy serves with valid token" do
+      key = unique_key()
+      AzureBlob.upload(key, "signed proxy data", ctx())
+      secret = "proxy-test-secret"
+      expires = System.system_time(:second) + 3600
+      token = AshStorage.Token.sign(secret, key, expires)
+
+      plug_opts =
+        AshStorage.Plug.Proxy.init(
+          service: {AshStorage.Service.AzureBlob, @service_opts},
+          secret: secret
+        )
+
+      conn =
+        Plug.Test.conn(
+          :get,
+          "/#{key}?token=#{URI.encode_www_form(token)}&expires=#{expires}"
+        )
+        |> Plug.Conn.fetch_query_params()
+        |> AshStorage.Plug.Proxy.call(plug_opts)
+
+      assert conn.status == 200
+      assert conn.resp_body == "signed proxy data"
     end
   end
 

--- a/test/ash_storage/service/azure_blob_integration_test.exs
+++ b/test/ash_storage/service/azure_blob_integration_test.exs
@@ -1,0 +1,419 @@
+defmodule AshStorage.Service.AzureBlobIntegrationTest do
+  @moduledoc """
+  Integration tests for AshStorage.Service.AzureBlob against a real Azurite instance.
+
+  These tests start an Azurite container via Docker, run the tests, and clean up.
+  Requires Docker to be available. Tagged with :azure_integration so they can be
+  excluded from normal test runs.
+  """
+  use ExUnit.Case, async: false
+
+  alias AshStorage.Service.AzureBlob
+  alias AshStorage.Service.Context
+
+  @moduletag :azure_integration
+
+  if is_nil(System.find_executable("docker")) do
+    @moduletag skip: "Docker is required to run Azure Blob integration tests"
+  end
+
+  @account "ashstorage"
+  @account_key Base.encode64(:binary.copy("azurite-test-key", 4))
+  @account_key_env "AZURE_STORAGE_ACCOUNT_KEY"
+  @container "uploads"
+  @port 19_001
+  @container_name "ash_storage_azurite_test"
+  @service_version "2020-12-06"
+  @endpoint_url "http://127.0.0.1:19001/ashstorage"
+
+  @service_opts [
+    account: @account,
+    container: @container,
+    account_key_env: @account_key_env,
+    endpoint_url: @endpoint_url
+  ]
+
+  setup_all do
+    previous_account_key = System.get_env(@account_key_env)
+    System.put_env(@account_key_env, @account_key)
+
+    on_exit(fn ->
+      cleanup_azurite()
+      restore_env(@account_key_env, previous_account_key)
+    end)
+
+    # Stop any leftover container from a previous run.
+    cleanup_azurite()
+
+    # Start Azurite with a deterministic test account/key so SAS signatures are stable.
+    case start_azurite() do
+      :ok ->
+        :ok = wait_for_azurite(30)
+        :ok = create_container()
+        :ok
+
+      {:error, {status, output}} ->
+        cleanup_azurite()
+
+        raise "Could not start Azurite Docker container (exit #{status}): #{String.trim(output)}"
+    end
+  end
+
+  defp ctx(extra_opts \\ []) do
+    Context.new(Keyword.merge(@service_opts, extra_opts))
+  end
+
+  defp start_azurite do
+    case System.cmd(
+           "docker",
+           [
+             "run",
+             "-d",
+             "--name",
+             @container_name,
+             "-p",
+             "#{@port}:10000",
+             "-e",
+             "AZURITE_ACCOUNTS=#{@account}:#{@account_key}",
+             "mcr.microsoft.com/azure-storage/azurite",
+             "azurite-blob",
+             "--blobHost",
+             "0.0.0.0",
+             "--blobPort",
+             "10000"
+           ],
+           stderr_to_stdout: true
+         ) do
+      {_, 0} -> :ok
+      {output, status} -> {:error, {status, output}}
+    end
+  end
+
+  defp cleanup_azurite do
+    System.cmd("docker", ["rm", "-f", @container_name], stderr_to_stdout: true)
+    :ok
+  end
+
+  defp restore_env(env_var, nil), do: System.delete_env(env_var)
+  defp restore_env(env_var, value), do: System.put_env(env_var, value)
+
+  describe "upload/3 and download/2" do
+    test "round-trips binary data" do
+      key = unique_key()
+      assert :ok = AzureBlob.upload(key, "hello azure", ctx())
+      assert {:ok, "hello azure"} = AzureBlob.download(key, ctx())
+    end
+
+    test "round-trips iolist data" do
+      key = unique_key()
+      assert :ok = AzureBlob.upload(key, ["hello", " ", "azure"], ctx())
+      assert {:ok, "hello azure"} = AzureBlob.download(key, ctx())
+    end
+
+    test "round-trips binary data (large)" do
+      key = unique_key()
+      data = :crypto.strong_rand_bytes(1024 * 1024)
+      assert :ok = AzureBlob.upload(key, data, ctx())
+      assert {:ok, ^data} = AzureBlob.download(key, ctx())
+    end
+
+    test "download returns not_found for missing key" do
+      assert {:error, :not_found} = AzureBlob.download(unique_key(), ctx())
+    end
+  end
+
+  describe "exists?/2" do
+    test "returns true for existing key" do
+      key = unique_key()
+      AzureBlob.upload(key, "data", ctx())
+      assert {:ok, true} = AzureBlob.exists?(key, ctx())
+    end
+
+    test "returns false for missing key" do
+      assert {:ok, false} = AzureBlob.exists?(unique_key(), ctx())
+    end
+  end
+
+  describe "delete/2" do
+    test "deletes an existing blob" do
+      key = unique_key()
+      AzureBlob.upload(key, "data", ctx())
+      assert {:ok, true} = AzureBlob.exists?(key, ctx())
+
+      assert :ok = AzureBlob.delete(key, ctx())
+      assert {:ok, false} = AzureBlob.exists?(key, ctx())
+    end
+
+    test "succeeds for missing key" do
+      assert :ok = AzureBlob.delete(unique_key(), ctx())
+    end
+  end
+
+  describe "url/2" do
+    test "generates a public URL" do
+      key = "folder/my file.txt"
+
+      assert AzureBlob.url(key, ctx()) ==
+               "#{@endpoint_url}/#{@container}/folder/my%20file.txt"
+    end
+
+    test "generates a presigned URL that works" do
+      key = unique_key()
+      AzureBlob.upload(key, "presigned content", ctx())
+
+      url = AzureBlob.url(key, ctx(presigned: true))
+      assert url =~ "sig="
+
+      assert {:ok, %{status: 200, body: "presigned content"}} = Req.get(url)
+    end
+
+    test "presigned URL respects expires_in" do
+      key = unique_key()
+      AzureBlob.upload(key, "expiry test", ctx())
+
+      url = AzureBlob.url(key, ctx(presigned: true, expires_in: 60))
+      params = url |> URI.parse() |> Map.fetch!(:query) |> URI.decode_query()
+
+      assert params["se"]
+      assert {:ok, %{status: 200, body: "expiry test"}} = Req.get(url)
+    end
+  end
+
+  describe "prefix option" do
+    test "prefixes keys in storage" do
+      key = unique_key()
+      prefixed_ctx = ctx(prefix: "uploads/")
+
+      assert :ok = AzureBlob.upload(key, "prefixed data", prefixed_ctx)
+      assert {:ok, "prefixed data"} = AzureBlob.download(key, prefixed_ctx)
+
+      # The actual Azure blob key should be prefixed.
+      assert {:ok, "prefixed data"} = AzureBlob.download("uploads/#{key}", ctx())
+    end
+  end
+
+  describe "configured SAS tokens" do
+    test "work for all operations when the token has the required permissions" do
+      sas_ctx =
+        @service_opts
+        |> Keyword.put(:account_key_env, "MISSING_AZURE_STORAGE_ACCOUNT_KEY")
+        |> Keyword.put(:sas_token, account_sas_token())
+        |> Context.new()
+
+      key = unique_key()
+
+      assert :ok = AzureBlob.upload(key, "sas token content", sas_ctx)
+      assert {:ok, true} = AzureBlob.exists?(key, sas_ctx)
+      assert {:ok, "sas token content"} = AzureBlob.download(key, sas_ctx)
+      assert :ok = AzureBlob.delete(key, sas_ctx)
+      assert {:ok, false} = AzureBlob.exists?(key, sas_ctx)
+    end
+  end
+
+  describe "direct_upload/2" do
+    test "generates a presigned PUT URL that accepts a browser-style upload" do
+      key = unique_key()
+
+      assert {:ok, %{url: upload_url, method: :put, headers: headers}} =
+               AzureBlob.direct_upload(key, ctx(content_type: "text/plain"))
+
+      assert headers["x-ms-blob-type"] == "BlockBlob"
+      assert headers["content-type"] == "text/plain"
+
+      assert {:ok, %{status: status}} =
+               Req.put(upload_url, body: "direct content", headers: headers)
+
+      assert status in 200..299
+      assert {:ok, "direct content"} = AzureBlob.download(key, ctx())
+    end
+  end
+
+  describe "end-to-end with Operations" do
+    setup do
+      AshStorage.Service.Test.reset!()
+      :ok
+    end
+
+    test "attach and load via Azure Blob Storage" do
+      # ConfigurablePost has otp_app: :ash_storage, so config overrides work.
+      Application.put_env(:ash_storage, AshStorage.Test.ConfigurablePost,
+        storage: [
+          service: {AshStorage.Service.AzureBlob, @service_opts}
+        ]
+      )
+
+      post =
+        AshStorage.Test.ConfigurablePost
+        |> Ash.Changeset.for_create(:create, %{title: "azure post"})
+        |> Ash.create!()
+
+      {:ok, %{blob: blob}} =
+        AshStorage.Operations.attach(post, :avatar, "azure file content",
+          filename: "azuretest.txt",
+          content_type: "text/plain"
+        )
+
+      assert blob.filename == "azuretest.txt"
+      assert blob.service_name == AshStorage.Service.AzureBlob
+
+      # Verify file is actually in Azure Blob Storage.
+      assert {:ok, "azure file content"} = AzureBlob.download(blob.key, ctx())
+
+      # Load the attachment via Ash.
+      post = Ash.load!(post, avatar: :blob)
+      assert post.avatar.blob.key == blob.key
+
+      # URL calculation should return an Azure Blob URL.
+      post = Ash.load!(post, :avatar_url)
+      assert post.avatar_url == "#{@endpoint_url}/#{@container}/#{blob.key}"
+
+      # Presigned URL calculation via config override.
+      Application.put_env(:ash_storage, AshStorage.Test.ConfigurablePost,
+        storage: [
+          service: {AshStorage.Service.AzureBlob, Keyword.put(@service_opts, :presigned, true)}
+        ]
+      )
+
+      # Re-read the post to clear cached calculations.
+      post = Ash.get!(AshStorage.Test.ConfigurablePost, post.id)
+      post = Ash.load!(post, :avatar_url)
+      assert post.avatar_url =~ "sig="
+
+      # Purge should remove from Azure Blob Storage. The persisted service opts only
+      # contain the env var name, so this also verifies env-backed async credentials.
+      {:ok, _} = AshStorage.Operations.purge(post, :avatar)
+      assert {:ok, false} = AzureBlob.exists?(blob.key, ctx())
+    after
+      Application.delete_env(:ash_storage, AshStorage.Test.ConfigurablePost)
+    end
+
+    test "direct upload flow via Azure Blob Storage" do
+      Application.put_env(:ash_storage, AshStorage.Test.ConfigurablePost,
+        storage: [
+          service: {AshStorage.Service.AzureBlob, @service_opts}
+        ]
+      )
+
+      # Step 1: Prepare direct upload — creates blob, gets presigned URL and headers.
+      {:ok, %{blob: blob, url: upload_url, method: :put, headers: headers}} =
+        AshStorage.Operations.prepare_direct_upload(
+          AshStorage.Test.ConfigurablePost,
+          :avatar,
+          filename: "direct.txt",
+          content_type: "text/plain",
+          byte_size: 14
+        )
+
+      assert blob.filename == "direct.txt"
+      assert blob.service_name == AshStorage.Service.AzureBlob
+      assert upload_url =~ "sig="
+      assert headers["x-ms-blob-type"] == "BlockBlob"
+
+      # Step 2: Client uploads directly to Azure using the presigned PUT URL.
+      assert {:ok, %{status: status}} =
+               Req.put(upload_url, body: "direct content", headers: headers)
+
+      assert status in 200..299
+
+      # Step 3: Create record and attach the blob.
+      post =
+        AshStorage.Test.ConfigurablePost
+        |> Ash.Changeset.for_create(:create, %{title: "direct upload post"})
+        |> Ash.create!()
+
+      post =
+        post
+        |> Ash.Changeset.for_update(:attach_avatar_blob, %{avatar_blob_id: blob.id})
+        |> Ash.update!()
+
+      # Verify file is actually in Azure Blob Storage.
+      assert {:ok, "direct content"} = AzureBlob.download(blob.key, ctx())
+
+      # Verify loadable via Ash.
+      post = Ash.load!(post, avatar: :blob)
+      assert post.avatar.blob.filename == "direct.txt"
+    after
+      Application.delete_env(:ash_storage, AshStorage.Test.ConfigurablePost)
+    end
+  end
+
+  # -- Helpers --
+
+  defp unique_key do
+    "test/#{System.unique_integer([:positive])}-#{:crypto.strong_rand_bytes(4) |> Base.encode16(case: :lower)}"
+  end
+
+  defp wait_for_azurite(0), do: {:error, :timeout}
+
+  defp wait_for_azurite(attempts) do
+    case :gen_tcp.connect(~c"127.0.0.1", @port, [:binary, active: false], 1000) do
+      {:ok, socket} ->
+        :gen_tcp.close(socket)
+        :ok
+
+      _ ->
+        Process.sleep(1000)
+        wait_for_azurite(attempts - 1)
+    end
+  end
+
+  defp create_container(attempts \\ 30)
+  defp create_container(0), do: {:error, :timeout}
+
+  defp create_container(attempts) do
+    url = "#{@endpoint_url}/#{@container}?restype=container&#{account_sas_token()}"
+
+    case Req.put(url, headers: %{"x-ms-version" => @service_version}, body: "") do
+      {:ok, %{status: status}} when status in [201, 202, 409] ->
+        :ok
+
+      _ ->
+        Process.sleep(1000)
+        create_container(attempts - 1)
+    end
+  end
+
+  defp account_sas_token do
+    permissions = "rwdlacup"
+    services = "b"
+    resource_types = "sco"
+    protocol = "https,http"
+    expiry_time = DateTime.utc_now() |> DateTime.add(3600, :second) |> format_time()
+
+    string_to_sign =
+      [
+        @account,
+        permissions,
+        services,
+        resource_types,
+        "",
+        expiry_time,
+        "",
+        protocol,
+        @service_version,
+        ""
+      ]
+      |> Enum.join("\n")
+
+    signature =
+      :crypto.mac(:hmac, :sha256, Base.decode64!(@account_key), string_to_sign)
+      |> Base.encode64()
+
+    [
+      {"sv", @service_version},
+      {"ss", services},
+      {"srt", resource_types},
+      {"sp", permissions},
+      {"se", expiry_time},
+      {"spr", protocol},
+      {"sig", signature}
+    ]
+    |> URI.encode_query()
+  end
+
+  defp format_time(%DateTime{} = datetime) do
+    datetime
+    |> DateTime.truncate(:second)
+    |> DateTime.to_iso8601()
+  end
+end

--- a/test/ash_storage/service/azure_blob_test.exs
+++ b/test/ash_storage/service/azure_blob_test.exs
@@ -23,12 +23,31 @@ defmodule AshStorage.Service.AzureBlobTest do
                "https://myaccount.blob.core.windows.net/uploads/tenant%20one/folder/my%20file.txt"
     end
 
+    test "treats an empty prefix as no prefix" do
+      ctx = Context.new(account: @account, container: @container, prefix: "")
+
+      assert AzureBlob.url("folder/blob.txt", ctx) ==
+               "https://myaccount.blob.core.windows.net/uploads/folder/blob.txt"
+    end
+
     test "uses custom endpoint URLs" do
       ctx =
         Context.new(
           account: "devstoreaccount1",
           container: @container,
           endpoint_url: "http://127.0.0.1:10000/devstoreaccount1"
+        )
+
+      assert AzureBlob.url("folder/blob.txt", ctx) ==
+               "http://127.0.0.1:10000/devstoreaccount1/uploads/folder/blob.txt"
+    end
+
+    test "trims trailing slashes from custom endpoint URLs" do
+      ctx =
+        Context.new(
+          account: "devstoreaccount1",
+          container: @container,
+          endpoint_url: "http://127.0.0.1:10000/devstoreaccount1/"
         )
 
       assert AzureBlob.url("folder/blob.txt", ctx) ==
@@ -116,6 +135,149 @@ defmodule AshStorage.Service.AzureBlobTest do
                    fn ->
                      AzureBlob.url("blob.txt", ctx)
                    end
+    end
+
+    test "raises a helpful error when the configured account key is not valid base64" do
+      ctx =
+        Context.new(
+          account: @account,
+          container: @container,
+          account_key: "not-base-64!!!",
+          presigned: true
+        )
+
+      assert_raise ArgumentError,
+                   ~r/could not generate Azure Blob SAS URL: :invalid_account_key/,
+                   fn ->
+                     AzureBlob.url("blob.txt", ctx)
+                   end
+    end
+
+    test "respects custom :service_version in SAS signatures" do
+      ctx =
+        Context.new(
+          account: @account,
+          container: @container,
+          account_key: @account_key,
+          presigned: true,
+          service_version: "2021-12-02"
+        )
+
+      params =
+        AzureBlob.url("blob.txt", ctx)
+        |> URI.parse()
+        |> Map.fetch!(:query)
+        |> URI.decode_query()
+
+      assert params["sv"] == "2021-12-02"
+    end
+
+    test "respects an explicit :signed_protocol override" do
+      ctx =
+        Context.new(
+          account: @account,
+          container: @container,
+          account_key: @account_key,
+          presigned: true,
+          signed_protocol: "https,http"
+        )
+
+      params =
+        AzureBlob.url("blob.txt", ctx)
+        |> URI.parse()
+        |> Map.fetch!(:query)
+        |> URI.decode_query()
+
+      assert params["spr"] == "https,http"
+    end
+  end
+
+  describe "credential resolution" do
+    @env_account_key "AZURE_TEST_ACCOUNT_KEY_#{System.unique_integer([:positive])}"
+    @env_sas_token "AZURE_TEST_SAS_TOKEN_#{System.unique_integer([:positive])}"
+
+    setup do
+      System.delete_env(@env_account_key)
+      System.delete_env(@env_sas_token)
+
+      on_exit(fn ->
+        System.delete_env(@env_account_key)
+        System.delete_env(@env_sas_token)
+      end)
+
+      :ok
+    end
+
+    test "reads :account_key from the configured env var" do
+      System.put_env(@env_account_key, @account_key)
+
+      ctx =
+        Context.new(
+          account: @account,
+          container: @container,
+          account_key_env: @env_account_key,
+          presigned: true
+        )
+
+      url = AzureBlob.url("blob.txt", ctx)
+      params = url |> URI.parse() |> Map.fetch!(:query) |> URI.decode_query()
+
+      assert params["sig"] ==
+               expected_signature("r", params["se"], "/blob/myaccount/uploads/blob.txt", "https")
+    end
+
+    test "treats an empty env var account key as missing" do
+      System.put_env(@env_account_key, "")
+
+      ctx =
+        Context.new(
+          account: @account,
+          container: @container,
+          account_key_env: @env_account_key,
+          presigned: true
+        )
+
+      assert_raise ArgumentError,
+                   ~r/could not generate Azure Blob SAS URL: :missing_credentials/,
+                   fn ->
+                     AzureBlob.url("blob.txt", ctx)
+                   end
+    end
+
+    test "reads :sas_token from the configured env var" do
+      System.put_env(@env_sas_token, "?sv=2020-12-06&sp=r&sig=envtoken")
+
+      ctx =
+        Context.new(
+          account: @account,
+          container: @container,
+          sas_token_env: @env_sas_token,
+          presigned: true
+        )
+
+      assert AzureBlob.url("blob.txt", ctx) =~ "sig=envtoken"
+    end
+
+    test "ignores empty env var SAS tokens and falls through to account key" do
+      System.put_env(@env_sas_token, "")
+
+      ctx =
+        Context.new(
+          account: @account,
+          container: @container,
+          account_key: @account_key,
+          sas_token_env: @env_sas_token,
+          presigned: true
+        )
+
+      params =
+        AzureBlob.url("blob.txt", ctx)
+        |> URI.parse()
+        |> Map.fetch!(:query)
+        |> URI.decode_query()
+
+      assert params["sig"] ==
+               expected_signature("r", params["se"], "/blob/myaccount/uploads/blob.txt", "https")
     end
   end
 
@@ -295,6 +457,52 @@ defmodule AshStorage.Service.AzureBlobTest do
       assert {:ok, %{status: 201}} = Req.put(url, body: "image data", headers: headers)
       assert {:ok, "image data"} = AzureBlob.download("direct/photo.png", ctx)
     end
+
+    test "sends the configured x-ms-version header on every request", %{
+      endpoint_url: endpoint_url,
+      server_state: server_state
+    } do
+      ctx = http_context(endpoint_url, service_version: "2021-12-02")
+      key = "version/blob.txt"
+
+      :ok = AzureBlob.upload(key, "data", ctx)
+      {:ok, _} = AzureBlob.download(key, ctx)
+      {:ok, true} = AzureBlob.exists?(key, ctx)
+      :ok = AzureBlob.delete(key, ctx)
+
+      for request <- recorded_requests(server_state) do
+        assert request.headers["x-ms-version"] == "2021-12-02"
+        assert request.query["sv"] == "2021-12-02"
+      end
+    end
+
+    test "surfaces unexpected upload statuses as errors", %{endpoint_url: endpoint_url} do
+      ctx = http_context(endpoint_url)
+      key = "force-status-400/explode.txt"
+
+      assert {:error, {400, _body}} = AzureBlob.upload(key, "boom", ctx)
+    end
+
+    test "surfaces unexpected download statuses as errors", %{endpoint_url: endpoint_url} do
+      ctx = http_context(endpoint_url)
+      key = "force-status-400/explode.txt"
+
+      assert {:error, {400, _body}} = AzureBlob.download(key, ctx)
+    end
+
+    test "surfaces unexpected delete statuses as errors", %{endpoint_url: endpoint_url} do
+      ctx = http_context(endpoint_url)
+      key = "force-status-400/explode.txt"
+
+      assert {:error, {400, _body}} = AzureBlob.delete(key, ctx)
+    end
+
+    test "surfaces unexpected exists? statuses as errors", %{endpoint_url: endpoint_url} do
+      ctx = http_context(endpoint_url)
+      key = "force-status-400/explode.txt"
+
+      assert {:error, {:unexpected_status, 400}} = AzureBlob.exists?(key, ctx)
+    end
   end
 
   describe "service_opts_fields/0" do
@@ -430,10 +638,21 @@ defmodule AshStorage.Service.AzureBlobTest do
       {:ok, key} ->
         request = Map.put(request, :key, key)
         record_request(server_state, request)
-        handle_blob_request(request, server_state)
+
+        case forced_status(key) do
+          {:ok, status} -> {status, ""}
+          :none -> handle_blob_request(request, server_state)
+        end
 
       :error ->
         {404, ""}
+    end
+  end
+
+  defp forced_status(key) do
+    case Regex.run(~r/^force-status-(\d{3})\//, key) do
+      [_, status] -> {:ok, String.to_integer(status)}
+      _ -> :none
     end
   end
 

--- a/test/ash_storage/service/azure_blob_test.exs
+++ b/test/ash_storage/service/azure_blob_test.exs
@@ -1,0 +1,230 @@
+defmodule AshStorage.Service.AzureBlobTest do
+  use ExUnit.Case, async: true
+
+  alias AshStorage.Service.AzureBlob
+  alias AshStorage.Service.Context
+
+  @account "myaccount"
+  @container "uploads"
+  @account_key Base.encode64("test account key")
+
+  describe "url/2" do
+    test "generates an unsigned public URL" do
+      ctx = Context.new(account: @account, container: @container)
+
+      assert AzureBlob.url("folder/my file.txt", ctx) ==
+               "https://myaccount.blob.core.windows.net/uploads/folder/my%20file.txt"
+    end
+
+    test "applies prefixes before encoding URLs" do
+      ctx = Context.new(account: @account, container: @container, prefix: "tenant one/")
+
+      assert AzureBlob.url("folder/my file.txt", ctx) ==
+               "https://myaccount.blob.core.windows.net/uploads/tenant%20one/folder/my%20file.txt"
+    end
+
+    test "uses custom endpoint URLs" do
+      ctx =
+        Context.new(
+          account: "devstoreaccount1",
+          container: @container,
+          endpoint_url: "http://127.0.0.1:10000/devstoreaccount1"
+        )
+
+      assert AzureBlob.url("folder/blob.txt", ctx) ==
+               "http://127.0.0.1:10000/devstoreaccount1/uploads/folder/blob.txt"
+    end
+
+    test "generates a SAS URL from an account key" do
+      ctx =
+        Context.new(
+          account: @account,
+          container: @container,
+          account_key: @account_key,
+          presigned: true,
+          expires_in: 60
+        )
+
+      url = AzureBlob.url("folder/my file.txt", ctx)
+      uri = URI.parse(url)
+      params = URI.decode_query(uri.query)
+
+      assert uri.scheme == "https"
+      assert uri.host == "myaccount.blob.core.windows.net"
+      assert uri.path == "/uploads/folder/my%20file.txt"
+      assert params["sv"] == "2020-12-06"
+      assert params["spr"] == "https"
+      assert params["sr"] == "b"
+      assert params["sp"] == "r"
+      assert params["se"]
+
+      assert params["sig"] ==
+               expected_signature(
+                 "r",
+                 params["se"],
+                 "/blob/myaccount/uploads/folder/my file.txt",
+                 "https"
+               )
+    end
+
+    test "includes response header overrides in SAS signatures" do
+      ctx =
+        Context.new(
+          account: @account,
+          container: @container,
+          account_key: @account_key,
+          presigned: true,
+          content_type: "image/png",
+          disposition: :attachment,
+          filename: "photo.png"
+        )
+
+      url = AzureBlob.url("photo.png", ctx)
+      params = url |> URI.parse() |> Map.fetch!(:query) |> URI.decode_query()
+
+      assert params["rsct"] == "image/png"
+      assert params["rscd"] == ~s(attachment; filename="photo.png")
+
+      assert params["sig"] ==
+               expected_signature(
+                 "r",
+                 params["se"],
+                 "/blob/myaccount/uploads/photo.png",
+                 "https",
+                 %{"rscd" => ~s(attachment; filename="photo.png"), "rsct" => "image/png"}
+               )
+    end
+
+    test "uses configured SAS tokens" do
+      ctx =
+        Context.new(
+          account: @account,
+          container: @container,
+          sas_token: "?sv=2020-12-06&sp=r&sig=abc123",
+          presigned: true
+        )
+
+      assert AzureBlob.url("blob.txt", ctx) ==
+               "https://myaccount.blob.core.windows.net/uploads/blob.txt?sv=2020-12-06&sp=r&sig=abc123"
+    end
+
+    test "raises a helpful error when a presigned URL lacks credentials" do
+      ctx = Context.new(account: @account, container: @container, presigned: true)
+
+      assert_raise ArgumentError,
+                   ~r/could not generate Azure Blob SAS URL: :missing_credentials/,
+                   fn ->
+                     AzureBlob.url("blob.txt", ctx)
+                   end
+    end
+  end
+
+  describe "direct_upload/2" do
+    test "generates a presigned PUT URL with Azure-required headers" do
+      ctx =
+        Context.new(
+          account: @account,
+          container: @container,
+          account_key: @account_key,
+          content_type: "image/png"
+        )
+
+      assert {:ok, %{url: url, method: :put, headers: headers}} =
+               AzureBlob.direct_upload("folder/photo.png", ctx)
+
+      params = url |> URI.parse() |> Map.fetch!(:query) |> URI.decode_query()
+
+      assert params["sp"] == "cw"
+      assert params["sr"] == "b"
+      assert headers["x-ms-blob-type"] == "BlockBlob"
+      assert headers["content-type"] == "image/png"
+    end
+
+    test "uses configured SAS tokens" do
+      ctx =
+        Context.new(
+          account: @account,
+          container: @container,
+          sas_token: "?sv=2020-12-06&sp=cw&sig=abc123"
+        )
+
+      assert {:ok, %{url: url, method: :put, headers: headers}} =
+               AzureBlob.direct_upload("blob.txt", ctx)
+
+      assert url ==
+               "https://myaccount.blob.core.windows.net/uploads/blob.txt?sv=2020-12-06&sp=cw&sig=abc123"
+
+      assert headers["x-ms-blob-type"] == "BlockBlob"
+    end
+
+    test "allows http endpoints by default for Azurite" do
+      ctx =
+        Context.new(
+          account: "devstoreaccount1",
+          container: @container,
+          account_key: @account_key,
+          endpoint_url: "http://127.0.0.1:10000/devstoreaccount1"
+        )
+
+      assert {:ok, %{url: url}} = AzureBlob.direct_upload("folder/photo.png", ctx)
+
+      uri = URI.parse(url)
+      params = URI.decode_query(uri.query)
+
+      assert uri.scheme == "http"
+      assert uri.path == "/devstoreaccount1/uploads/folder/photo.png"
+      assert params["spr"] == "https,http"
+    end
+
+    test "returns an error without credentials" do
+      ctx = Context.new(account: @account, container: @container)
+
+      assert {:error, :missing_credentials} = AzureBlob.direct_upload("blob.txt", ctx)
+    end
+  end
+
+  describe "service_opts_fields/0" do
+    test "declares fields needed to persist service options" do
+      fields = AzureBlob.service_opts_fields()
+
+      assert fields[:account][:allow_nil?] == false
+      assert fields[:container][:allow_nil?] == false
+      assert fields[:account_key_env][:type] == :string
+      assert fields[:sas_token_env][:type] == :string
+      refute Keyword.has_key?(fields, :account_key)
+      refute Keyword.has_key?(fields, :sas_token)
+    end
+  end
+
+  defp expected_signature(
+         permissions,
+         expiry,
+         canonicalized_resource,
+         protocol,
+         response_headers \\ %{}
+       ) do
+    string_to_sign =
+      [
+        permissions,
+        "",
+        expiry,
+        canonicalized_resource,
+        "",
+        "",
+        protocol,
+        "2020-12-06",
+        "b",
+        "",
+        "",
+        Map.get(response_headers, "rscc", ""),
+        Map.get(response_headers, "rscd", ""),
+        Map.get(response_headers, "rsce", ""),
+        Map.get(response_headers, "rscl", ""),
+        Map.get(response_headers, "rsct", "")
+      ]
+      |> Enum.join("\n")
+
+    :crypto.mac(:hmac, :sha256, "test account key", string_to_sign)
+    |> Base.encode64()
+  end
+end

--- a/test/ash_storage/service/azure_blob_test.exs
+++ b/test/ash_storage/service/azure_blob_test.exs
@@ -183,6 +183,120 @@ defmodule AshStorage.Service.AzureBlobTest do
     end
   end
 
+  describe "configured SAS token permissions" do
+    test "direct_upload/2 fails fast when the configured token lacks create/write" do
+      ctx =
+        Context.new(
+          account: @account,
+          container: @container,
+          sas_token: "?sv=2020-12-06&sp=r&sig=abc123"
+        )
+
+      assert {:error, {:sas_missing_permissions, details}} =
+               AzureBlob.direct_upload("blob.txt", ctx)
+
+      assert details[:required] == "cw"
+      assert details[:granted] == "r"
+      assert details[:missing] in ["cw", "wc"]
+    end
+
+    test "url/2 raises a helpful error when the presign token lacks read" do
+      ctx =
+        Context.new(
+          account: @account,
+          container: @container,
+          sas_token: "?sv=2020-12-06&sp=cw&sig=abc123",
+          presigned: true
+        )
+
+      assert_raise ArgumentError, ~r/sas_missing_permissions/, fn ->
+        AzureBlob.url("blob.txt", ctx)
+      end
+    end
+
+    test "tokens with broader permissions are accepted for narrower operations" do
+      ctx =
+        Context.new(
+          account: @account,
+          container: @container,
+          sas_token: "?sv=2020-12-06&sp=racwdl&sig=abc123",
+          presigned: true
+        )
+
+      assert {:ok, %{url: url}} = AzureBlob.direct_upload("blob.txt", ctx)
+      assert url =~ "sp=racwdl"
+      assert AzureBlob.url("blob.txt", ctx) =~ "sp=racwdl"
+    end
+
+    test "tokens without an `sp` parameter fall through to Azure" do
+      ctx =
+        Context.new(
+          account: @account,
+          container: @container,
+          sas_token: "?sv=2020-12-06&sig=abc123",
+          presigned: true
+        )
+
+      assert AzureBlob.url("blob.txt", ctx) =~ "sig=abc123"
+      assert {:ok, _} = AzureBlob.direct_upload("blob.txt", ctx)
+    end
+  end
+
+  describe "HTTP storage operations" do
+    setup do
+      start_mock_azure()
+    end
+
+    test "upload, download, exists?, and delete round-trip through HTTP", %{
+      endpoint_url: endpoint_url,
+      server_state: server_state
+    } do
+      ctx = http_context(endpoint_url)
+      key = "folder/hello.txt"
+
+      assert :ok = AzureBlob.upload(key, "hello azure", ctx)
+      assert {:ok, true} = AzureBlob.exists?(key, ctx)
+      assert {:ok, "hello azure"} = AzureBlob.download(key, ctx)
+      assert :ok = AzureBlob.delete(key, ctx)
+      assert {:ok, false} = AzureBlob.exists?(key, ctx)
+      assert {:error, :not_found} = AzureBlob.download(key, ctx)
+
+      [put_request, head_request, get_request, delete_request, missing_head, missing_get] =
+        recorded_requests(server_state)
+
+      assert put_request.method == "PUT"
+      assert put_request.path == "/devstoreaccount1/uploads/folder/hello.txt"
+      assert put_request.query["sp"] == "cw"
+      assert put_request.headers["x-ms-blob-type"] == "BlockBlob"
+      assert put_request.headers["x-ms-version"] == "2020-12-06"
+      assert put_request.body == "hello azure"
+
+      assert head_request.method == "HEAD"
+      assert head_request.query["sp"] == "r"
+
+      assert get_request.method == "GET"
+      assert get_request.query["sp"] == "r"
+
+      assert delete_request.method == "DELETE"
+      assert delete_request.query["sp"] == "d"
+
+      assert missing_head.method == "HEAD"
+      assert missing_get.method == "GET"
+    end
+
+    test "direct upload URL works with returned headers", %{endpoint_url: endpoint_url} do
+      ctx = http_context(endpoint_url, content_type: "image/png")
+
+      assert {:ok, %{url: url, method: :put, headers: headers}} =
+               AzureBlob.direct_upload("direct/photo.png", ctx)
+
+      assert headers["x-ms-blob-type"] == "BlockBlob"
+      assert headers["content-type"] == "image/png"
+      assert {:ok, %{status: 201}} = Req.put(url, body: "image data", headers: headers)
+      assert {:ok, "image data"} = AzureBlob.download("direct/photo.png", ctx)
+    end
+  end
+
   describe "service_opts_fields/0" do
     test "declares fields needed to persist service options" do
       fields = AzureBlob.service_opts_fields()
@@ -195,6 +309,237 @@ defmodule AshStorage.Service.AzureBlobTest do
       refute Keyword.has_key?(fields, :sas_token)
     end
   end
+
+  defp http_context(endpoint_url, extra_opts \\ []) do
+    Context.new(
+      Keyword.merge(
+        [
+          account: "devstoreaccount1",
+          container: @container,
+          account_key: @account_key,
+          endpoint_url: endpoint_url
+        ],
+        extra_opts
+      )
+    )
+  end
+
+  defp start_mock_azure do
+    {:ok, server_state} = Agent.start(fn -> %{objects: %{}, requests: []} end)
+
+    {:ok, listener} =
+      :gen_tcp.listen(0, [:binary, packet: :raw, active: false, reuseaddr: true])
+
+    {:ok, port} = :inet.port(listener)
+    acceptor = spawn(fn -> accept_loop(listener, server_state) end)
+
+    on_exit(fn ->
+      :gen_tcp.close(listener)
+      Process.exit(acceptor, :shutdown)
+      Agent.stop(server_state)
+    end)
+
+    {:ok, endpoint_url: "http://127.0.0.1:#{port}/devstoreaccount1", server_state: server_state}
+  end
+
+  defp accept_loop(listener, server_state) do
+    case :gen_tcp.accept(listener) do
+      {:ok, socket} ->
+        spawn(fn -> serve_connection(socket, server_state) end)
+        accept_loop(listener, server_state)
+
+      {:error, _reason} ->
+        :ok
+    end
+  end
+
+  defp serve_connection(socket, server_state) do
+    case read_request(socket) do
+      {:ok, request} ->
+        {status, body} = handle_mock_request(request, server_state)
+        send_response(socket, status, body)
+
+      {:error, _reason} ->
+        send_response(socket, 400, "")
+    end
+  after
+    :gen_tcp.close(socket)
+  end
+
+  defp read_request(socket) do
+    with {:ok, raw_request} <- recv_until_headers(socket, <<>>),
+         [raw_headers, buffered_body] <- :binary.split(raw_request, "\r\n\r\n"),
+         [request_line | header_lines] <- String.split(raw_headers, "\r\n"),
+         [method, target, _version] <- String.split(request_line, " ", parts: 3) do
+      headers = parse_headers(header_lines)
+      content_length = headers |> Map.get("content-length", "0") |> String.to_integer()
+
+      with {:ok, body} <- read_body(socket, buffered_body, content_length) do
+        uri = URI.parse(target)
+
+        {:ok,
+         %{
+           method: method,
+           path: uri.path,
+           query: URI.decode_query(uri.query || ""),
+           headers: headers,
+           body: body
+         }}
+      end
+    else
+      _ -> {:error, :bad_request}
+    end
+  end
+
+  defp recv_until_headers(socket, buffer) do
+    case :binary.match(buffer, "\r\n\r\n") do
+      {_start, _length} ->
+        {:ok, buffer}
+
+      :nomatch ->
+        case :gen_tcp.recv(socket, 0, 5_000) do
+          {:ok, chunk} -> recv_until_headers(socket, buffer <> chunk)
+          {:error, reason} -> {:error, reason}
+        end
+    end
+  end
+
+  defp read_body(_socket, buffered_body, 0), do: {:ok, binary_part(buffered_body, 0, 0)}
+
+  defp read_body(socket, buffered_body, content_length)
+       when byte_size(buffered_body) < content_length do
+    case :gen_tcp.recv(socket, content_length - byte_size(buffered_body), 5_000) do
+      {:ok, chunk} -> read_body(socket, buffered_body <> chunk, content_length)
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp read_body(_socket, buffered_body, content_length) do
+    {:ok, binary_part(buffered_body, 0, content_length)}
+  end
+
+  defp parse_headers(header_lines) do
+    Map.new(header_lines, fn line ->
+      [name, value] = String.split(line, ":", parts: 2)
+      {String.downcase(name), String.trim_leading(value)}
+    end)
+  end
+
+  defp handle_mock_request(request, server_state) do
+    case blob_key_from_path(request.path) do
+      {:ok, key} ->
+        request = Map.put(request, :key, key)
+        record_request(server_state, request)
+        handle_blob_request(request, server_state)
+
+      :error ->
+        {404, ""}
+    end
+  end
+
+  defp handle_blob_request(%{method: "PUT"} = request, server_state) do
+    cond do
+      !has_permission?(request, "w") ->
+        {403, ""}
+
+      request.headers["x-ms-blob-type"] != "BlockBlob" ->
+        {400, ""}
+
+      true ->
+        Agent.update(server_state, fn state ->
+          %{state | objects: Map.put(state.objects, request.key, request.body)}
+        end)
+
+        {201, ""}
+    end
+  end
+
+  defp handle_blob_request(%{method: "GET"} = request, server_state) do
+    if has_permission?(request, "r") do
+      case stored_object(server_state, request.key) do
+        {:ok, body} -> {200, body}
+        :error -> {404, ""}
+      end
+    else
+      {403, ""}
+    end
+  end
+
+  defp handle_blob_request(%{method: "HEAD"} = request, server_state) do
+    if has_permission?(request, "r") do
+      case stored_object(server_state, request.key) do
+        {:ok, _body} -> {200, ""}
+        :error -> {404, ""}
+      end
+    else
+      {403, ""}
+    end
+  end
+
+  defp handle_blob_request(%{method: "DELETE"} = request, server_state) do
+    if has_permission?(request, "d") do
+      existed? =
+        Agent.get_and_update(server_state, fn state ->
+          {Map.has_key?(state.objects, request.key),
+           %{state | objects: Map.delete(state.objects, request.key)}}
+        end)
+
+      if existed?, do: {202, ""}, else: {404, ""}
+    else
+      {403, ""}
+    end
+  end
+
+  defp handle_blob_request(_request, _server_state), do: {405, ""}
+
+  defp blob_key_from_path(path) do
+    case String.split(path || "", "/", trim: true) do
+      [_account, _container | key_segments] when key_segments != [] ->
+        {:ok, Enum.map_join(key_segments, "/", &URI.decode/1)}
+
+      _ ->
+        :error
+    end
+  end
+
+  defp has_permission?(request, permission) do
+    request.query |> Map.get("sp", "") |> String.contains?(permission)
+  end
+
+  defp stored_object(server_state, key) do
+    Agent.get(server_state, fn state -> Map.fetch(state.objects, key) end)
+  end
+
+  defp record_request(server_state, request) do
+    Agent.update(server_state, fn state -> %{state | requests: [request | state.requests]} end)
+  end
+
+  defp recorded_requests(server_state) do
+    Agent.get(server_state, fn state -> Enum.reverse(state.requests) end)
+  end
+
+  defp send_response(socket, status, body) do
+    response = [
+      "HTTP/1.1 ",
+      Integer.to_string(status),
+      " ",
+      reason_phrase(status),
+      "\r\ncontent-length: ",
+      Integer.to_string(byte_size(body)),
+      "\r\nconnection: close\r\n\r\n",
+      body
+    ]
+
+    :gen_tcp.send(socket, response)
+  end
+
+  defp reason_phrase(200), do: "OK"
+  defp reason_phrase(201), do: "Created"
+  defp reason_phrase(202), do: "Accepted"
+  defp reason_phrase(400), do: "Bad Request"
+  defp reason_phrase(403), do: "Forbidden"
+  defp reason_phrase(404), do: "Not Found"
+  defp reason_phrase(405), do: "Method Not Allowed"
 
   defp expected_signature(
          permissions,

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,6 +1,6 @@
 AshStorage.Service.Test.start()
 
-exclude = [:s3_integration]
+exclude = [:s3_integration, :azure_integration]
 
 exclude =
   case AshStorage.TestRepo.start_link() do


### PR DESCRIPTION
# Summary

We are adding support for Azure blob by creating a new service. https://github.com/ash-project/ash_storage/issues/14

The implementation is tested with a local Azurite instance (started via docker) note that if you don't have the image the test will download it during setup. This implementation has been also tested in a real Ash application using `ash_storage` with a staging Azure blob instance. 

I've made attempts to think through any edge cases that one might encounter and they should be covered. However I'm not an expert with Azure blob so I might have missed something. The core happy paths work well and without issues.

Finally want to note that the changes to the doc `documentation/topics/direct-uploads.md` around headers were done because Azure requires extra request headers. This makes the docs more consistent even if it's not mandatory for S3 (everything still works when passing the headers)

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [x] Documentation changes
- [x] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
