### PR TITLE
Revert "fix: return raw bytes from S3 and AzureBlob downloads (#26)"

### DIFF
--- a/lib/ash_storage/service.ex
+++ b/lib/ash_storage/service.ex
@@ -43,18 +43,10 @@ defmodule AshStorage.Service do
   @doc """
   Download a file from the storage service.
 
-  By default, services built on `Req` (S3, AzureBlob) run Req's `decode_body`
-  step, so the returned body reflects the stored object's `content-type` —
-  `application/json` comes back as a decoded map, `text/csv` as parsed rows,
-  `application/zip` already unzipped, and so on. File-based services (Disk,
-  Mirror) always return raw bytes.
-
-  Callers that need the exact uploaded bytes — writing to disk, streaming to
-  a client, verifying a checksum — should pass `decode_body: false` via the
-  service options on the `Req`-based services.
+  Returns the file contents as binary data.
   """
   @callback download(key(), Context.t()) ::
-              {:ok, term()} | {:error, term()}
+              {:ok, binary()} | {:error, term()}
 
   @doc """
   Delete a file from the storage service.

--- a/lib/ash_storage/service/azure_blob.ex
+++ b/lib/ash_storage/service/azure_blob.ex
@@ -49,10 +49,6 @@ if Code.ensure_loaded?(Req) do
       (default: `"2020-12-06"`)
     - `:signed_protocol` - SAS protocol restriction. Defaults to `"https"`, or
       `"https,http"` for `http://` endpoints
-    - `:decode_body` - whether `download/2` runs Req's content-type response
-      decoding (JSON → map, CSV → rows, gzip → unzipped, etc.). Defaults to
-      `true` to match Req's own default; pass `false` when you need the raw
-      uploaded bytes.
 
     ## Azure setup
 
@@ -113,8 +109,7 @@ if Code.ensure_loaded?(Req) do
         expires_in: [type: :integer],
         direct_upload_expires_in: [type: :integer],
         service_version: [type: :string],
-        signed_protocol: [type: :string],
-        decode_body: [type: :boolean]
+        signed_protocol: [type: :string]
       ]
     end
 
@@ -153,11 +148,8 @@ if Code.ensure_loaded?(Req) do
     def download(key, %AshStorage.Service.Context{} = ctx) do
       full_key = prefixed_key(key, ctx)
 
-      decode_body? = Keyword.get(ctx.service_opts, :decode_body, true)
-
       with {:ok, url} <- signed_blob_url(full_key, ctx, permissions: "r", expires_in: 900),
-           {:ok, %{status: 200, body: body}} <-
-             Req.get(url, headers: base_headers(ctx), decode_body: decode_body?),
+           {:ok, %{status: 200, body: body}} <- Req.get(url, headers: base_headers(ctx)),
            :ok <- verify_md5(body, ctx.expected_md5) do
         {:ok, body}
       else

--- a/lib/ash_storage/service/s3.ex
+++ b/lib/ash_storage/service/s3.ex
@@ -23,10 +23,6 @@ if Code.ensure_loaded?(ReqS3) do
     - `:secret_access_key` - AWS secret access key (falls back to `AWS_SECRET_ACCESS_KEY` env var)
     - `:endpoint_url` - custom endpoint URL for S3-compatible services (e.g. MinIO, Tigris)
     - `:prefix` - optional key prefix (e.g. `"uploads/"`)
-    - `:decode_body` - whether `download/2` runs Req's content-type response
-      decoding (JSON → map, CSV → rows, gzip → unzipped, etc.). Defaults to
-      `true` to match Req's own default; pass `false` when you need the raw
-      uploaded bytes.
     """
 
     @behaviour AshStorage.Service
@@ -39,8 +35,7 @@ if Code.ensure_loaded?(ReqS3) do
         access_key_id: [type: :string],
         secret_access_key: [type: :string],
         endpoint_url: [type: :string],
-        prefix: [type: :string],
-        decode_body: [type: :boolean]
+        prefix: [type: :string]
       ]
     end
 
@@ -64,10 +59,7 @@ if Code.ensure_loaded?(ReqS3) do
     def download(key, %AshStorage.Service.Context{} = ctx) do
       full_key = prefixed_key(key, ctx)
 
-      decode_body? = Keyword.get(ctx.service_opts, :decode_body, true)
-
-      with {:ok, %{status: 200, body: body}} <-
-             Req.get(req(ctx), url: "/#{full_key}", decode_body: decode_body?),
+      with {:ok, %{status: 200, body: body}} <- Req.get(req(ctx), url: "/#{full_key}"),
            :ok <- verify_md5(body, ctx.expected_md5) do
         {:ok, body}
       else

--- a/test/ash_storage/service/azure_blob_integration_test.exs
+++ b/test/ash_storage/service/azure_blob_integration_test.exs
@@ -142,32 +142,6 @@ defmodule AshStorage.Service.AzureBlobIntegrationTest do
       assert {:error, :not_found} = AzureBlob.download(unique_key(), ctx())
     end
 
-    test "auto-decodes JSON bodies by default" do
-      key = unique_key()
-      json = ~s({"name":"Alice","score":95})
-
-      assert :ok = AzureBlob.upload(key, json, ctx(content_type: "application/json"))
-
-      assert {:ok, %{"name" => "Alice", "score" => 95}} =
-               AzureBlob.download(key, ctx())
-    end
-
-    test "decode_body: false returns raw CSV bytes" do
-      key = unique_key()
-      csv = "Name,Score\nAlice,95\nBob,87\n"
-
-      assert :ok = AzureBlob.upload(key, csv, ctx(content_type: "text/csv"))
-      assert {:ok, ^csv} = AzureBlob.download(key, ctx(decode_body: false))
-    end
-
-    test "decode_body: false returns raw JSON bytes" do
-      key = unique_key()
-      json = ~s({"name":"Alice","score":95})
-
-      assert :ok = AzureBlob.upload(key, json, ctx(content_type: "application/json"))
-      assert {:ok, ^json} = AzureBlob.download(key, ctx(decode_body: false))
-    end
-
     test "accepts upload when ctx expected_md5 matches the body" do
       key = unique_key()
       data = "checksum-verified payload"

--- a/test/ash_storage/service/s3_integration_test.exs
+++ b/test/ash_storage/service/s3_integration_test.exs
@@ -88,24 +88,6 @@ defmodule AshStorage.Service.S3IntegrationTest do
       assert {:error, :not_found} = S3.download(unique_key(), ctx())
     end
 
-    test "auto-decodes JSON bodies by default" do
-      key = unique_key()
-      json = ~s({"name":"Alice","score":95})
-
-      :ok = raw_put_with_content_type(key, json, "application/json")
-
-      assert {:ok, %{"name" => "Alice", "score" => 95}} =
-               S3.download(key, ctx())
-    end
-
-    test "decode_body: false returns raw bytes for content-typed objects" do
-      key = unique_key()
-      csv = "Name,Score\nAlice,95\nBob,87\n"
-
-      :ok = raw_put_with_content_type(key, csv, "text/csv")
-      assert {:ok, ^csv} = S3.download(key, ctx(decode_body: false))
-    end
-
     test "accepts upload when ctx expected_md5 matches the body" do
       key = unique_key()
       data = "checksum-verified payload"
@@ -378,24 +360,6 @@ defmodule AshStorage.Service.S3IntegrationTest do
   end
 
   # -- Helpers --
-
-  defp raw_put_with_content_type(key, body, content_type) do
-    url = "#{@service_opts[:endpoint_url]}/#{@bucket}/#{key}"
-
-    {:ok, %{status: status}} =
-      Req.put(url,
-        body: body,
-        headers: %{"content-type" => content_type},
-        aws_sigv4: [
-          service: :s3,
-          region: @service_opts[:region],
-          access_key_id: @service_opts[:access_key_id],
-          secret_access_key: @service_opts[:secret_access_key]
-        ]
-      )
-
-    if status in 200..299, do: :ok, else: {:error, status}
-  end
 
   defp unique_key do
     "test/#{System.unique_integer([:positive])}-#{:crypto.strong_rand_bytes(4) |> Base.encode16(case: :lower)}"


### PR DESCRIPTION
## Summary
- Reverts #26 (commit f93e6b6), which changed S3 and AzureBlob downloads to return raw bytes.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Chores