### PR TITLE
fix: return raw bytes from S3 and AzureBlob downloads

### DIFF
--- a/lib/ash_storage/service.ex
+++ b/lib/ash_storage/service.ex
@@ -43,7 +43,15 @@ defmodule AshStorage.Service do
   @doc """
   Download a file from the storage service.
 
-  Returns the file contents as binary data.
+  Returns the file contents as raw bytes, regardless of the stored object's
+  `content-type`. Callers writing the result to disk or piping it to a client
+  get back the exact bytes that were uploaded.
+
+  Services built on `Req` (S3, AzureBlob) disable Req's default `decode_body`
+  step to honor this contract — otherwise a `text/csv` object would come back
+  as parsed rows and `application/json` as an Elixir map. Services may expose
+  a `:decode_body` service option to opt back into content-type decoding when
+  that is what the caller wants.
   """
   @callback download(key(), Context.t()) ::
               {:ok, binary()} | {:error, term()}

--- a/lib/ash_storage/service/azure_blob.ex
+++ b/lib/ash_storage/service/azure_blob.ex
@@ -49,6 +49,9 @@ if Code.ensure_loaded?(Req) do
       (default: `"2020-12-06"`)
     - `:signed_protocol` - SAS protocol restriction. Defaults to `"https"`, or
       `"https,http"` for `http://` endpoints
+    - `:decode_body` - opt back into Req's content-type response decoding on
+      `download/2`. Defaults to `false`; see the `AshStorage.Service`
+      `download/2` callback docs for the raw-bytes contract.
 
     ## Azure setup
 
@@ -109,7 +112,8 @@ if Code.ensure_loaded?(Req) do
         expires_in: [type: :integer],
         direct_upload_expires_in: [type: :integer],
         service_version: [type: :string],
-        signed_protocol: [type: :string]
+        signed_protocol: [type: :string],
+        decode_body: [type: :boolean]
       ]
     end
 
@@ -148,8 +152,11 @@ if Code.ensure_loaded?(Req) do
     def download(key, %AshStorage.Service.Context{} = ctx) do
       full_key = prefixed_key(key, ctx)
 
+      decode_body? = Keyword.get(ctx.service_opts, :decode_body, false)
+
       with {:ok, url} <- signed_blob_url(full_key, ctx, permissions: "r", expires_in: 900),
-           {:ok, %{status: 200, body: body}} <- Req.get(url, headers: base_headers(ctx)),
+           {:ok, %{status: 200, body: body}} <-
+             Req.get(url, headers: base_headers(ctx), decode_body: decode_body?),
            :ok <- verify_md5(body, ctx.expected_md5) do
         {:ok, body}
       else

--- a/lib/ash_storage/service/s3.ex
+++ b/lib/ash_storage/service/s3.ex
@@ -23,6 +23,9 @@ if Code.ensure_loaded?(ReqS3) do
     - `:secret_access_key` - AWS secret access key (falls back to `AWS_SECRET_ACCESS_KEY` env var)
     - `:endpoint_url` - custom endpoint URL for S3-compatible services (e.g. MinIO, Tigris)
     - `:prefix` - optional key prefix (e.g. `"uploads/"`)
+    - `:decode_body` - opt back into Req's content-type response decoding on
+      `download/2`. Defaults to `false`; see the `AshStorage.Service`
+      `download/2` callback docs for the raw-bytes contract.
     """
 
     @behaviour AshStorage.Service
@@ -35,7 +38,8 @@ if Code.ensure_loaded?(ReqS3) do
         access_key_id: [type: :string],
         secret_access_key: [type: :string],
         endpoint_url: [type: :string],
-        prefix: [type: :string]
+        prefix: [type: :string],
+        decode_body: [type: :boolean]
       ]
     end
 
@@ -59,7 +63,10 @@ if Code.ensure_loaded?(ReqS3) do
     def download(key, %AshStorage.Service.Context{} = ctx) do
       full_key = prefixed_key(key, ctx)
 
-      with {:ok, %{status: 200, body: body}} <- Req.get(req(ctx), url: "/#{full_key}"),
+      decode_body? = Keyword.get(ctx.service_opts, :decode_body, false)
+
+      with {:ok, %{status: 200, body: body}} <-
+             Req.get(req(ctx), url: "/#{full_key}", decode_body: decode_body?),
            :ok <- verify_md5(body, ctx.expected_md5) do
         {:ok, body}
       else

--- a/test/ash_storage/service/azure_blob_integration_test.exs
+++ b/test/ash_storage/service/azure_blob_integration_test.exs
@@ -142,6 +142,32 @@ defmodule AshStorage.Service.AzureBlobIntegrationTest do
       assert {:error, :not_found} = AzureBlob.download(unique_key(), ctx())
     end
 
+    test "round-trips CSV bytes without auto-decoding" do
+      key = unique_key()
+      csv = "Name,Score\nAlice,95\nBob,87\n"
+
+      assert :ok = AzureBlob.upload(key, csv, ctx(content_type: "text/csv"))
+      assert {:ok, ^csv} = AzureBlob.download(key, ctx())
+    end
+
+    test "round-trips JSON bytes without auto-decoding" do
+      key = unique_key()
+      json = ~s({"name":"Alice","score":95})
+
+      assert :ok = AzureBlob.upload(key, json, ctx(content_type: "application/json"))
+      assert {:ok, ^json} = AzureBlob.download(key, ctx())
+    end
+
+    test "decode_body: true opts back into Req's content-type decoding" do
+      key = unique_key()
+      json = ~s({"name":"Alice","score":95})
+
+      assert :ok = AzureBlob.upload(key, json, ctx(content_type: "application/json"))
+
+      assert {:ok, %{"name" => "Alice", "score" => 95}} =
+               AzureBlob.download(key, ctx(decode_body: true))
+    end
+
     test "accepts upload when ctx expected_md5 matches the body" do
       key = unique_key()
       data = "checksum-verified payload"

--- a/test/ash_storage/service/s3_integration_test.exs
+++ b/test/ash_storage/service/s3_integration_test.exs
@@ -88,6 +88,24 @@ defmodule AshStorage.Service.S3IntegrationTest do
       assert {:error, :not_found} = S3.download(unique_key(), ctx())
     end
 
+    test "round-trips bytes uploaded with a CSV content-type without auto-decoding" do
+      key = unique_key()
+      csv = "Name,Score\nAlice,95\nBob,87\n"
+
+      :ok = raw_put_with_content_type(key, csv, "text/csv")
+      assert {:ok, ^csv} = S3.download(key, ctx())
+    end
+
+    test "decode_body: true opts back into Req's content-type decoding" do
+      key = unique_key()
+      json = ~s({"name":"Alice","score":95})
+
+      :ok = raw_put_with_content_type(key, json, "application/json")
+
+      assert {:ok, %{"name" => "Alice", "score" => 95}} =
+               S3.download(key, ctx(decode_body: true))
+    end
+
     test "accepts upload when ctx expected_md5 matches the body" do
       key = unique_key()
       data = "checksum-verified payload"
@@ -360,6 +378,24 @@ defmodule AshStorage.Service.S3IntegrationTest do
   end
 
   # -- Helpers --
+
+  defp raw_put_with_content_type(key, body, content_type) do
+    url = "#{@service_opts[:endpoint_url]}/#{@bucket}/#{key}"
+
+    {:ok, %{status: status}} =
+      Req.put(url,
+        body: body,
+        headers: %{"content-type" => content_type},
+        aws_sigv4: [
+          service: :s3,
+          region: @service_opts[:region],
+          access_key_id: @service_opts[:access_key_id],
+          secret_access_key: @service_opts[:secret_access_key]
+        ]
+      )
+
+    if status in 200..299, do: :ok, else: {:error, status}
+  end
 
   defp unique_key do
     "test/#{System.unique_integer([:positive])}-#{:crypto.strong_rand_bytes(4) |> Base.encode16(case: :lower)}"


### PR DESCRIPTION
Fixes https://github.com/ash-project/ash_storage/issues/27

> [!WARNING]
> **Breaking change.** `AshStorage.Service.AzureBlob.download/2` and `AshStorage.Service.S3.download/2` previously returned content-type-decoded values (maps for JSON, lists of lists for CSV, extracted archives for tar/zip, etc.) despite their `{:ok, binary()}` typespec. After this change they return the raw bytes that were stored, matching the documented contract. Callers that depended on the implicit decoding must now opt back in via `service_opts: [decode_body: true]` on the service context.

## Summary

`AshStorage.Service.AzureBlob.download/2` and `AshStorage.Service.S3.download/2` are typed `{:ok, binary()} | {:error, term()}`, but they delegate to `Req.get/2` without disabling Req's default `decode_body` step. That step deserialises response bodies based on the response's `Content-Type` header:

| Format       | Decoder                                                |
|--------------|--------------------------------------------------------|
| `json`       | `Jason.decode/2`                                       |
| `csv`        | `NimbleCSV.RFC4180.parse_string/2` (if loaded)         |
| `tar`, `tgz` | `:erl_tar.extract/2`                                   |
| `zip`        | `:zip.unzip/2`                                         |
| `gzip`       | `:zlib.gunzip/1`                                       |
| `zst`        | `:ezstd.decompress/1` (if loaded)                      |

So a blob stored with `Content-Type: application/zip` comes back already unzipped; `text/csv` comes back as a list of lists; JSON comes back as a map. The typespec claims `binary()`; the runtime returns whatever Req decided to decode.

This was discovered in the wild when a CSV uploaded to chat became unreadable to the downstream parser. The Disk service uses `File.read/1`, so unit tests never hit it; only the Azure/S3 paths do.

This also silently breaks the `verify_md5/2` check that runs immediately after the download (see #27): when the body has been auto-decoded, MD5 is computed over the iodata flattening of the decoded term, not the original bytes — so the digest never matches what the server stored.

## Change

Both `Req`-based services now pass `decode_body: false` to `Req.get/2`, so the response body comes back as the raw bytes that were uploaded — matching the documented `{:ok, binary()}` contract and keeping `verify_md5/2` honest. `decode_body: false` is preferred over `raw: true` because the latter also disables `decompress_body`, which we want to keep for transparent gzip/br handling.

Callers that want Req's content-type-based decoding can opt back in via a new `:decode_body` service option (defaults to `false`) on either service:

```elixir
AshStorage.Service.AzureBlob.download(key, Context.new(account: ..., container: ..., decode_body: true))
AshStorage.Service.S3.download(key, Context.new(bucket: ..., decode_body: true))
```

The option is registered in both adapters' `service_opts_fields/0` so consumers that introspect the schema see it. The `AshStorage.Service.download/2` callback doc has also been updated to spell out the raw-bytes contract and the opt-in escape hatch.

## Tests

New integration tests in both suites:

- `test/ash_storage/service/azure_blob_integration_test.exs` — CSV and JSON round-trip as raw bytes by default; `decode_body: true` returns the parsed map.
- `test/ash_storage/service/s3_integration_test.exs` — same, with a small `raw_put_with_content_type/3` helper that sets `Content-Type` via a signed PUT (since `S3.upload/3` doesn't currently expose the header).

The new tests are tagged `:azure_integration` / `:s3_integration` like the existing ones, so they only run when Docker is available.

## Acceptance Criteria

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [x] Documentation changes
- [x] Features include unit/acceptance tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)