### PR TITLE
fix: preserve Mirror context attributes in build_child_ctx

### DIFF
--- a/lib/ash_storage/service/mirror.ex
+++ b/lib/ash_storage/service/mirror.ex
@@ -215,13 +215,7 @@ defmodule AshStorage.Service.Mirror do
   end
 
   defp build_child_ctx(child, %Context{} = parent) do
-    %Context{
-      service_opts: child.opts,
-      resource: parent.resource,
-      attachment: parent.attachment,
-      actor: parent.actor,
-      tenant: parent.tenant
-    }
+    %{parent | service_opts: child.opts}
   end
 
   defp try_in_order([], _fun), do: {:error, :not_found}

--- a/test/ash_storage/service/mirror_test.exs
+++ b/test/ash_storage/service/mirror_test.exs
@@ -180,6 +180,34 @@ defmodule AshStorage.Service.MirrorTest do
     end
   end
 
+  describe "context propagation" do
+    test "download propagates expected_md5 to the child (mismatch fails)", %{ctx: ctx} do
+      Mirror.upload("file.txt", "hello", ctx)
+
+      ctx_with_bad_md5 = Context.put_expected_md5(ctx, Base.encode64(:erlang.md5("not-hello")))
+
+      assert {:error, :checksum_mismatch} = Mirror.download("file.txt", ctx_with_bad_md5)
+    end
+
+    test "download succeeds when expected_md5 matches", %{ctx: ctx} do
+      Mirror.upload("file.txt", "hello", ctx)
+
+      ctx_with_good_md5 = Context.put_expected_md5(ctx, Base.encode64(:erlang.md5("hello")))
+
+      assert {:ok, "hello"} = Mirror.download("file.txt", ctx_with_good_md5)
+    end
+
+    test "fall-through to secondary still propagates expected_md5", %{ctx: ctx} do
+      TestService.upload("file.txt", "secondary-bytes", Context.new(name: @secondary_table))
+
+      good = Context.put_expected_md5(ctx, Base.encode64(:erlang.md5("secondary-bytes")))
+      assert {:ok, "secondary-bytes"} = Mirror.download("file.txt", good)
+
+      bad = Context.put_expected_md5(ctx, Base.encode64(:erlang.md5("wrong")))
+      assert {:error, :checksum_mismatch} = Mirror.download("file.txt", bad)
+    end
+  end
+
   describe "missing :services" do
     test "raises a clear error when context has no :services" do
       ctx = Context.new([])


### PR DESCRIPTION
## Summary

`Mirror.build_child_ctx/2` was rebuilding the child `Context` from a hard-coded subset of fields (`service_opts`, `resource`, `attachment`, `actor`, `tenant`), silently dropping anything else the parent context carried — e.g. `expected_md5` and any future `Context` additions.

Replace the rebuild with `%{parent | service_opts: child.opts}` so every attribute on the parent propagates to the child, with only the per-service opts overridden.

## Tests

New `context propagation` describe block in `test/ash_storage/service/mirror_test.exs` covers:

- download fails with `:checksum_mismatch` when `expected_md5` is wrong (proves the field now reaches the child)
- download succeeds when `expected_md5` matches
- fall-through to the secondary service still propagates `expected_md5`

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)