### PR TITLE
Fix S3 content-type, filename not set + support plug upload type.

### DIFF
--- a/documentation/topics/file-arguments.md
+++ b/documentation/topics/file-arguments.md
@@ -101,3 +101,36 @@ The difference from `HandleFileArgument`:
 | Argument type | `Ash.Type.File` | `:file` |
 
 Use `HandleFileArgument` when you need `write_attributes` or want the tightest integration. Use `AttachFile` for simpler cases.
+
+## Direct uploads with `Operations.attach/4`
+
+When you don't want to wire a file argument into an Ash action — typical in a Phoenix controller that handles the upload imperatively — call `AshStorage.Operations.attach/4` directly. The `io` argument accepts the same shapes as the file-argument path, including `%Plug.Upload{}`:
+
+```elixir
+def upload(conn, %{"id" => post_id, "image" => %Plug.Upload{} = upload}) do
+  {:ok, post} = Ash.get(MyApp.Post, post_id, actor: conn.assigns.current_user)
+
+  {:ok, %{blob: blob}} =
+    AshStorage.Operations.attach(post, :images, upload,
+      filename: upload.filename || "image",
+      content_type: upload.content_type || "application/octet-stream",
+      actor: conn.assigns.current_user
+    )
+
+  json(conn, %{blob_id: blob.id})
+end
+```
+
+The `io` argument can be any of:
+
+| Value | Source on disk? | Notes |
+|---|---|---|
+| `%Plug.Upload{}` | Yes (`upload.path`) | Read for you; pass the struct itself, not `upload.path`. |
+| `%Ash.Type.File{}` | Yes | Same value you'd accept on a file argument. |
+| `%File.Stream{}` | Yes | Collected into memory. |
+| binary | No — in-memory | The *bytes* to store. Not a filesystem path. |
+| iodata list | No — in-memory | Flattened to a binary. |
+
+> **Gotcha:** the binary clause matches **any** binary, including a filesystem path string. If you pass `upload.path` (the path string) instead of `upload` (the struct), `attach/4` will happily upload the literal path as the blob body. Always pass the struct.
+
+The `:filename` and `:content_type` options are forwarded to the configured service via the `Context` (see `AshStorage.Service.Context`) — for example, the bundled S3 service uses `:content_type` to set the `Content-Type` header on the PUT.

--- a/lib/ash_storage/changes/attach.ex
+++ b/lib/ash_storage/changes/attach.ex
@@ -289,6 +289,20 @@ defmodule AshStorage.Changes.Attach do
   defp normalize_upload({:error, _} = error), do: error
 
   # -- IO helpers --
+  #
+  # Materialize the caller-supplied `io` value into the raw bytes that will
+  # be uploaded. Accepted shapes:
+  #
+  #   * `%Ash.Type.File{}` — opened and read in binary mode.
+  #   * `%File.Stream{}`   — collected into a single binary.
+  #   * `%Plug.Upload{}`   — read from disk via `File.read!/1`. Without
+  #     this clause the struct's `:path` field (a string) would match
+  #     the generic `is_binary/1` clause below and the *path* would be
+  #     uploaded as the body. See documentation/topics/file-arguments.md
+  #     for usage from Phoenix controllers.
+  #   * binary             — used verbatim as the bytes to store. Note
+  #     that this is the *bytes*, not a filesystem path.
+  #   * iodata list        — flattened into a binary.
 
   defp read_io(%Ash.Type.File{} = file) do
     {:ok, device} = Ash.Type.File.open(file, [:read, :binary])
@@ -298,6 +312,13 @@ defmodule AshStorage.Changes.Attach do
   end
 
   defp read_io(%File.Stream{} = stream), do: Enum.into(stream, <<>>, &IO.iodata_to_binary/1)
+
+  # Matched by `__struct__` atom so this module does not require `:plug`
+  # as a compile-time dependency; `Plug.Upload` is only resolved here as
+  # an atom literal.
+  defp read_io(%{__struct__: Plug.Upload, path: path}) when is_binary(path),
+    do: File.read!(path)
+
   defp read_io(data) when is_binary(data), do: data
   defp read_io(data) when is_list(data), do: IO.iodata_to_binary(data)
 

--- a/lib/ash_storage/changes/attach.ex
+++ b/lib/ash_storage/changes/attach.ex
@@ -252,7 +252,17 @@ defmodule AshStorage.Changes.Attach do
     key = AshStorage.generate_key()
     checksum = :crypto.hash(:md5, data) |> Base.encode64()
     byte_size = byte_size(data)
-    ctx = Context.put_expected_md5(ctx, checksum)
+
+    # Make the upload metadata visible to the service so it can record it
+    # on the underlying object — e.g. the S3 service forwards
+    # `:content_type` as the `Content-Type` header on PUT. Without this
+    # step the service would only know the bytes and the key, not what
+    # those bytes are. The blob row still receives the values via
+    # `blob_attrs` below; this just mirrors them onto the context.
+    ctx =
+      ctx
+      |> Context.put_expected_md5(checksum)
+      |> Context.put_blob_metadata(content_type: content_type, filename: filename)
 
     with {:ok, extra_blob_attrs} <- normalize_upload(service_mod.upload(key, data, ctx)) do
       blob_resource = Info.storage_blob_resource!(resource)

--- a/lib/ash_storage/changes/handle_file_argument.ex
+++ b/lib/ash_storage/changes/handle_file_argument.ex
@@ -334,6 +334,12 @@ defmodule AshStorage.Changes.HandleFileArgument do
   end
 
   defp read_io(%File.Stream{} = stream), do: Enum.into(stream, <<>>, &IO.iodata_to_binary/1)
+
+  # See `AshStorage.Changes.Attach.read_io/1` for the rationale on this
+  # clause and the full input contract.
+  defp read_io(%{__struct__: Plug.Upload, path: path}) when is_binary(path),
+    do: File.read!(path)
+
   defp read_io(data) when is_binary(data), do: data
   defp read_io(data) when is_list(data), do: IO.iodata_to_binary(data)
 

--- a/lib/ash_storage/changes/handle_file_argument.ex
+++ b/lib/ash_storage/changes/handle_file_argument.ex
@@ -293,7 +293,14 @@ defmodule AshStorage.Changes.HandleFileArgument do
     key = AshStorage.generate_key()
     checksum = :crypto.hash(:md5, data) |> Base.encode64()
     byte_size = byte_size(data)
-    ctx = Context.put_expected_md5(ctx, checksum)
+
+    # See `AshStorage.Changes.Attach.upload_and_create_blob/6` for the
+    # rationale on threading the blob's content_type / filename into the
+    # context before calling `service_mod.upload/3`.
+    ctx =
+      ctx
+      |> Context.put_expected_md5(checksum)
+      |> Context.put_blob_metadata(content_type: content_type, filename: filename)
 
     with {:ok, extra_blob_attrs} <- normalize_upload(service_mod.upload(key, data, ctx)) do
       blob_resource = Info.storage_blob_resource!(resource)

--- a/lib/ash_storage/service.ex
+++ b/lib/ash_storage/service.ex
@@ -36,6 +36,12 @@ defmodule AshStorage.Service do
   May return `:ok` or `{:ok, extra_blob_attrs}`. When a map is returned, its entries
   are merged into the blob record on creation. This allows wrapping services (e.g.
   encryption) to store per-file metadata such as encryption keys on the blob.
+
+  The Context carries the upload's `:content_type` and `:filename` when set
+  by the caller of `attach/4`, so services can record them on the underlying
+  object (e.g. the bundled S3 service forwards `:content_type` as the
+  `Content-Type` header on PUT). See `AshStorage.Service.Context` for the
+  full list of fields.
   """
   @callback upload(key(), iodata() | File.Stream.t(), Context.t()) ::
               :ok | {:ok, map()} | {:error, term()}

--- a/lib/ash_storage/service/context.ex
+++ b/lib/ash_storage/service/context.ex
@@ -4,8 +4,8 @@ defmodule AshStorage.Service.Context do
 
   Contains the service-specific options along with broader context about the
   resource, attachment, actor, and tenant. This allows services to make
-  decisions based on who is performing the operation and what resource/attachment
-  it applies to.
+  decisions based on who is performing the operation and what resource /
+  attachment it applies to.
 
   ## Fields
 
@@ -16,8 +16,26 @@ defmodule AshStorage.Service.Context do
   - `:tenant` - the current tenant, or `nil`
   - `:expected_md5` - base64-encoded raw MD5 (16 bytes → 24 chars) of the bytes
     being uploaded or expected to be downloaded. On `upload/3` it is sent as
-    `Content-MD5` so S3/Azure reject mismatched bodies; on `download/2` it is
-    compared against the hash of the fetched bytes. `nil` skips verification.
+    `Content-MD5` so S3 / Azure reject mismatched bodies; on `download/2` it
+    is compared against the hash of the fetched bytes. `nil` skips
+    verification.
+  - `:content_type` - MIME type of the bytes being uploaded (set by the
+    bundled attach / file-argument changes from the caller-supplied
+    `:content_type` option). Services use this to record the type on the
+    underlying object — e.g. the S3 service forwards it as the
+    `Content-Type` header on PUT. `nil` means the caller didn't supply one
+    and the service should fall back to whatever default it normally uses.
+  - `:filename` - original filename of the bytes being uploaded. Reserved
+    for services that record it as object metadata (e.g. an S3
+    `Content-Disposition` header, an Azure `x-ms-meta-filename` header).
+    Not currently consumed by any bundled service. `nil` when unknown.
+
+  ## Lifecycle
+
+  Most callbacks see a Context constructed by the bundled changes
+  (`AshStorage.Changes.Attach`, `HandleFileArgument`, etc.). Custom flows
+  can build one with `new/2` and refine it via `put_expected_md5/2` and
+  `put_blob_metadata/2` before invoking a service callback directly.
   """
   defstruct [
     :resource,
@@ -25,6 +43,8 @@ defmodule AshStorage.Service.Context do
     :actor,
     :tenant,
     :expected_md5,
+    :content_type,
+    :filename,
     service_opts: []
   ]
 
@@ -34,11 +54,16 @@ defmodule AshStorage.Service.Context do
           actor: term(),
           tenant: term(),
           expected_md5: String.t() | nil,
+          content_type: String.t() | nil,
+          filename: String.t() | nil,
           service_opts: keyword()
         }
 
   @doc """
   Build a context from service opts and optional extras.
+
+  Recognized keys in `extras`: `:resource`, `:attachment`, `:actor`,
+  `:tenant`, `:content_type`, `:filename`. Anything else is ignored.
   """
   def new(service_opts, extras \\ []) when is_list(service_opts) do
     %__MODULE__{
@@ -46,7 +71,9 @@ defmodule AshStorage.Service.Context do
       resource: Keyword.get(extras, :resource),
       attachment: Keyword.get(extras, :attachment),
       actor: Keyword.get(extras, :actor),
-      tenant: Keyword.get(extras, :tenant)
+      tenant: Keyword.get(extras, :tenant),
+      content_type: Keyword.get(extras, :content_type),
+      filename: Keyword.get(extras, :filename)
     }
   end
 
@@ -54,9 +81,36 @@ defmodule AshStorage.Service.Context do
   Set or clear the expected MD5 on a context.
 
   The value must be a base64-encoded raw MD5 — exactly the format that the
-  `Content-MD5` HTTP header expects.
+  `Content-MD5` HTTP header expects. Pass `nil` to disable verification.
   """
   def put_expected_md5(%__MODULE__{} = ctx, md5) when is_binary(md5) or is_nil(md5) do
     %{ctx | expected_md5: md5}
+  end
+
+  @doc """
+  Set the blob's `:content_type` and / or `:filename` on the context.
+
+  Used by the bundled attach changes to forward caller-supplied metadata
+  to the service before calling `upload/3`. Pass only the keys you want
+  to update; existing values are preserved for keys you don't supply.
+
+  ## Examples
+
+      iex> ctx = AshStorage.Service.Context.new([])
+      iex> ctx = AshStorage.Service.Context.put_blob_metadata(ctx, content_type: "image/jpeg")
+      iex> ctx.content_type
+      "image/jpeg"
+
+      iex> ctx = AshStorage.Service.Context.new([], content_type: "image/png")
+      iex> ctx = AshStorage.Service.Context.put_blob_metadata(ctx, filename: "cover.png")
+      iex> {ctx.content_type, ctx.filename}
+      {"image/png", "cover.png"}
+  """
+  def put_blob_metadata(%__MODULE__{} = ctx, opts) when is_list(opts) do
+    %{
+      ctx
+      | content_type: Keyword.get(opts, :content_type, ctx.content_type),
+        filename: Keyword.get(opts, :filename, ctx.filename)
+    }
   end
 end

--- a/lib/ash_storage/service/s3.ex
+++ b/lib/ash_storage/service/s3.ex
@@ -51,6 +51,7 @@ if Code.ensure_loaded?(ReqS3) do
       put_opts =
         [url: "/#{full_key}", body: data]
         |> maybe_put_content_md5(ctx, data)
+        |> maybe_put_content_type(ctx)
 
       case Req.put(req(ctx), put_opts) do
         {:ok, %{status: status}} when status in 200..299 -> :ok
@@ -262,6 +263,23 @@ if Code.ensure_loaded?(ReqS3) do
     end
 
     defp maybe_put_content_md5(put_opts, _ctx, _data), do: put_opts
+
+    # Forward the blob's Content-Type so the stored object reports the
+    # right MIME type. Without this S3 records `binary/octet-stream` on
+    # every object (the SigV4 default for PUTs with no `Content-Type`
+    # header), which makes browsers refuse to render the response as the
+    # type the caller intended — most visibly, `<img src>` requests hit
+    # Opaque Response Blocking and fail silently.
+    #
+    # We only set the header when the context actually carries a value,
+    # so callers who never set `:content_type` keep the old behaviour.
+    defp maybe_put_content_type(put_opts, %{content_type: ct})
+         when is_binary(ct) and ct != "" do
+      existing = Keyword.get(put_opts, :headers, [])
+      Keyword.put(put_opts, :headers, [{"content-type", ct} | existing])
+    end
+
+    defp maybe_put_content_type(put_opts, _ctx), do: put_opts
 
     defp verify_md5(_data, nil), do: :ok
 

--- a/test/ash_storage/operations_test.exs
+++ b/test/ash_storage/operations_test.exs
@@ -57,6 +57,35 @@ defmodule AshStorage.OperationsTest do
       File.rm(Path.join(System.tmp_dir!(), "ash_storage_test_file.txt"))
     end
 
+    test "accepts %Plug.Upload{} and uploads the file bytes (not the path string)" do
+      # Regression: before the dedicated `read_io/1` clause, the struct's
+      # `:path` was a binary that matched the generic `is_binary/1` clause
+      # and the literal path string was uploaded as the blob body.
+      post = create_post!()
+      path = Path.join(System.tmp_dir!(), "ash_storage_plug_upload_test.bin")
+      contents = "actual file bytes via Plug.Upload"
+      File.write!(path, contents)
+
+      upload = %Plug.Upload{
+        path: path,
+        filename: "via-plug.bin",
+        content_type: "application/octet-stream"
+      }
+
+      {:ok, %{blob: blob}} =
+        Operations.attach(post, :cover_image, upload,
+          filename: upload.filename,
+          content_type: upload.content_type
+        )
+
+      # Bytes stored = file contents, NOT the path string. byte_size is the
+      # most economical proof — a regression would store the ~50-char path.
+      assert blob.byte_size == byte_size(contents)
+      assert {:ok, ^contents} = AshStorage.Service.Test.download(blob.key, [])
+    after
+      File.rm(Path.join(System.tmp_dir!(), "ash_storage_plug_upload_test.bin"))
+    end
+
     test "replaces existing has_one_attached" do
       post = create_post!()
 

--- a/test/ash_storage/service/context_test.exs
+++ b/test/ash_storage/service/context_test.exs
@@ -1,0 +1,64 @@
+defmodule AshStorage.Service.ContextTest do
+  use ExUnit.Case, async: true
+
+  alias AshStorage.Service.Context
+
+  describe "new/2" do
+    test "defaults the new blob-metadata fields to nil" do
+      ctx = Context.new([])
+
+      assert ctx.content_type == nil
+      assert ctx.filename == nil
+    end
+
+    test "accepts :content_type and :filename in extras" do
+      ctx = Context.new([], content_type: "image/jpeg", filename: "cover.jpg")
+
+      assert ctx.content_type == "image/jpeg"
+      assert ctx.filename == "cover.jpg"
+    end
+  end
+
+  describe "put_blob_metadata/2" do
+    test "sets :content_type while leaving :filename untouched" do
+      ctx =
+        Context.new([])
+        |> Context.put_blob_metadata(content_type: "image/png")
+
+      assert ctx.content_type == "image/png"
+      assert ctx.filename == nil
+    end
+
+    test "sets :filename while leaving :content_type untouched" do
+      ctx =
+        Context.new([], content_type: "image/png")
+        |> Context.put_blob_metadata(filename: "cover.png")
+
+      assert ctx.content_type == "image/png"
+      assert ctx.filename == "cover.png"
+    end
+
+    test "preserves unrelated context fields" do
+      ctx =
+        Context.new([bucket: "b"], actor: :alice, tenant: :acme)
+        |> Context.put_expected_md5("MD5MD5MD5MD5MD5MD5MD5MD5")
+        |> Context.put_blob_metadata(content_type: "image/gif", filename: "g.gif")
+
+      assert ctx.actor == :alice
+      assert ctx.tenant == :acme
+      assert ctx.service_opts == [bucket: "b"]
+      assert ctx.expected_md5 == "MD5MD5MD5MD5MD5MD5MD5MD5"
+      assert ctx.content_type == "image/gif"
+      assert ctx.filename == "g.gif"
+    end
+
+    test "treats absent keys as no-ops (keeps existing values)" do
+      ctx =
+        Context.new([], content_type: "image/jpeg", filename: "a.jpg")
+        |> Context.put_blob_metadata([])
+
+      assert ctx.content_type == "image/jpeg"
+      assert ctx.filename == "a.jpg"
+    end
+  end
+end

--- a/test/ash_storage/service/s3_integration_test.exs
+++ b/test/ash_storage/service/s3_integration_test.exs
@@ -122,6 +122,35 @@ defmodule AshStorage.Service.S3IntegrationTest do
       assert {:error, {400, _body}} = S3.upload(key, "actual", ctx)
       assert {:ok, false} = S3.exists?(key, ctx())
     end
+
+    test "records ctx.content_type on the stored object" do
+      # Regression: prior to forwarding Content-Type on PUT, S3-compatible
+      # stores recorded `binary/octet-stream` on every object regardless
+      # of what the caller passed.
+      key = unique_key()
+
+      ctx =
+        ctx()
+        |> Context.put_blob_metadata(content_type: "image/jpeg", filename: "x.jpg")
+
+      assert :ok = S3.upload(key, "fake jpeg bytes", ctx)
+
+      # MinIO answers HEAD with the stored Content-Type. Read it directly
+      # off the wire — `S3.head/2` only surfaces size + checksums.
+      assert head_content_type(key) == "image/jpeg"
+    end
+
+    test "omits Content-Type header when ctx.content_type is nil" do
+      # Strictly additive: a Context with no content_type should produce
+      # the same wire request as before the change. The stored object
+      # falls back to the service default (`application/octet-stream` on
+      # MinIO; `binary/octet-stream` on real AWS S3) — neither is a
+      # caller-supplied value.
+      key = unique_key()
+      assert :ok = S3.upload(key, "no content type", ctx())
+
+      assert head_content_type(key) in ["application/octet-stream", "binary/octet-stream"]
+    end
   end
 
   describe "exists?/2" do
@@ -429,5 +458,22 @@ defmodule AshStorage.Service.S3IntegrationTest do
       {:ok, %{status: status}} when status in [200, 409] -> :ok
       other -> {:error, other}
     end
+  end
+
+  # Issue a SigV4-signed HEAD straight at MinIO and return the
+  # `content-type` response header. `S3.head/2` only surfaces
+  # size + checksums, so we go to the wire when we need the actual MIME.
+  defp head_content_type(key) do
+    {:ok, %{status: 200, headers: headers}} =
+      Req.head("http://localhost:#{@port}/#{@bucket}/#{key}",
+        aws_sigv4: [
+          service: :s3,
+          region: "us-east-1",
+          access_key_id: @service_opts[:access_key_id],
+          secret_access_key: @service_opts[:secret_access_key]
+        ]
+      )
+
+    headers |> Map.get("content-type", []) |> List.first()
   end
 end


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [x] Chores
- [x] Documentation changes
- [x] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

This closes #33 and I thoroughly reviewed each change, turned them into well-reviewable commits, ensured there are tests and ran the integration tests again minio.

I think this is a valuable addition to the lib. I personally require it to properly use ash_storage for my project.


I have thoroughly reviewed the AI policy. All commits are AI generated but thoroughly reviewed (2h) even though I think they are rather small and easy to follow. This PR is written by hand below checklist.