### PR TITLE
Thread scope (actor/tenant/authorize?/tracer) through internal operations

### DIFF
--- a/lib/ash_storage/changes/attach.ex
+++ b/lib/ash_storage/changes/attach.ex
@@ -380,6 +380,7 @@ defmodule AshStorage.Changes.Attach do
     case find_attachments(record, attachment_def, context_opts) do
       {:ok, []} -> {:ok, :noop}
       {:ok, existing} -> purge_attachments(existing, service_mod, ctx, context_opts)
+      {:error, _} = error -> error
     end
   end
 
@@ -450,8 +451,7 @@ defmodule AshStorage.Changes.Attach do
     attachment_resource
     |> Ash.Query.filter(^filter)
     |> Ash.Query.load(:blob)
-    |> Ash.Query.set_tenant(context_opts[:tenant])
-    |> Ash.read()
+    |> Ash.read(Keyword.take(context_opts, [:actor, :tenant, :authorize?, :tracer]))
   end
 
   defp purge_attachments(attachments, service_mod, ctx, context_opts) do

--- a/lib/ash_storage/changes/attach_blob.ex
+++ b/lib/ash_storage/changes/attach_blob.ex
@@ -218,8 +218,7 @@ defmodule AshStorage.Changes.AttachBlob do
     attachment_resource
     |> Ash.Query.filter(^filter)
     |> Ash.Query.load(:blob)
-    |> Ash.Query.set_tenant(context_opts[:tenant])
-    |> Ash.read()
+    |> Ash.read(Keyword.take(context_opts, [:actor, :tenant, :authorize?, :tracer]))
   end
 
   defp purge_attachments(attachments, service_mod, ctx, context_opts) do

--- a/lib/ash_storage/changes/detach.ex
+++ b/lib/ash_storage/changes/detach.ex
@@ -10,8 +10,9 @@ defmodule AshStorage.Changes.Detach do
   def init(opts), do: {:ok, opts}
 
   @impl true
-  def change(changeset, opts, _context) do
+  def change(changeset, opts, context) do
     attachment_name = opts[:attachment_name]
+    context_opts = Ash.Context.to_opts(context)
 
     Ash.Changeset.after_action(changeset, fn _changeset, record ->
       resource = record.__struct__
@@ -19,9 +20,9 @@ defmodule AshStorage.Changes.Detach do
       all? = Ash.Changeset.get_argument(changeset, :all) || false
 
       with {:ok, attachment_def} <- Info.attachment(resource, attachment_name),
-           {:ok, attachments} <- find_attachments(record, attachment_def),
+           {:ok, attachments} <- find_attachments(record, attachment_def, context_opts),
            {:ok, to_detach} <- select_for_detach(attachments, attachment_def, blob_id, all?) do
-        case destroy_attachment_records(to_detach) do
+        case destroy_attachment_records(to_detach, context_opts) do
           {:ok, destroyed} ->
             {:ok, Ash.Resource.put_metadata(record, :detached_attachments, destroyed)}
 
@@ -45,7 +46,7 @@ defmodule AshStorage.Changes.Detach do
   end
 
   # sobelow_skip ["DOS.BinToAtom"]
-  defp find_attachments(record, attachment_def) do
+  defp find_attachments(record, attachment_def, context_opts) do
     resource = record.__struct__
     attachment_resource = Info.storage_attachment_resource!(resource)
     record_id = Map.get(record, :id) |> to_string()
@@ -72,12 +73,14 @@ defmodule AshStorage.Changes.Detach do
     attachment_resource
     |> Ash.Query.filter(^filter)
     |> Ash.Query.load(:blob)
-    |> Ash.read()
+    |> Ash.read(Keyword.take(context_opts, [:actor, :tenant, :authorize?, :tracer]))
   end
 
-  defp destroy_attachment_records(attachments) do
+  defp destroy_attachment_records(attachments, context_opts) do
+    destroy_opts = Keyword.merge(context_opts, action: :destroy, return_destroyed?: true)
+
     Enum.reduce_while(attachments, {:ok, []}, fn att, {:ok, acc} ->
-      case Ash.destroy(att, action: :destroy, return_destroyed?: true) do
+      case Ash.destroy(att, destroy_opts) do
         {:ok, destroyed} -> {:cont, {:ok, [destroyed | acc]}}
         {:error, error} -> {:halt, {:error, error}}
       end

--- a/lib/ash_storage/changes/handle_dependent_attachments.ex
+++ b/lib/ash_storage/changes/handle_dependent_attachments.ex
@@ -3,10 +3,11 @@ defmodule AshStorage.Changes.HandleDependentAttachments do
   use Ash.Resource.Change
 
   @impl true
-  def change(changeset, _opts, _context) do
+  def change(changeset, _opts, context) do
     if changeset.action.soft? do
       changeset
     else
+      context_opts = Ash.Context.to_opts(context)
       resource = changeset.resource
       async? = async_purge?(resource)
 
@@ -15,7 +16,7 @@ defmodule AshStorage.Changes.HandleDependentAttachments do
       changeset =
         Ash.Changeset.before_action(changeset, fn changeset ->
           record = changeset.data
-          attachments_by_name = prefetch_attachments(record)
+          attachments_by_name = prefetch_attachments(record, context_opts)
           Ash.Changeset.put_context(changeset, :__ash_storage_attachments__, attachments_by_name)
         end)
 
@@ -48,7 +49,7 @@ defmodule AshStorage.Changes.HandleDependentAttachments do
   end
 
   # sobelow_skip ["DOS.BinToAtom"]
-  defp prefetch_attachments(record) do
+  defp prefetch_attachments(record, context_opts) do
     resource = record.__struct__
     attachment_defs = AshStorage.Info.attachments(resource)
 
@@ -80,7 +81,7 @@ defmodule AshStorage.Changes.HandleDependentAttachments do
           case attachment_resource
                |> Ash.Query.filter(^filter)
                |> Ash.Query.load(:blob)
-               |> Ash.read() do
+               |> Ash.read(Keyword.take(context_opts, [:actor, :tenant, :authorize?, :tracer])) do
             {:ok, attachments} -> Map.put(acc, attachment_def.name, attachments)
             _ -> acc
           end

--- a/lib/ash_storage/changes/handle_file_argument.ex
+++ b/lib/ash_storage/changes/handle_file_argument.ex
@@ -389,6 +389,7 @@ defmodule AshStorage.Changes.HandleFileArgument do
     case find_attachments(record, attachment_def) do
       {:ok, []} -> {:ok, :noop}
       {:ok, existing} -> purge_attachments(existing, service_mod, ctx)
+      {:error, _} = error -> error
     end
   end
 

--- a/lib/ash_storage/changes/purge.ex
+++ b/lib/ash_storage/changes/purge.ex
@@ -11,8 +11,9 @@ defmodule AshStorage.Changes.Purge do
   def init(opts), do: {:ok, opts}
 
   @impl true
-  def change(changeset, opts, _context) do
+  def change(changeset, opts, context) do
     attachment_name = opts[:attachment_name]
+    context_opts = Ash.Context.to_opts(context)
 
     Ash.Changeset.after_action(changeset, fn _changeset, record ->
       resource = record.__struct__
@@ -20,12 +21,12 @@ defmodule AshStorage.Changes.Purge do
       all? = Ash.Changeset.get_argument(changeset, :all) || false
 
       with {:ok, attachment_def} <- Info.attachment(resource, attachment_name),
-           {:ok, attachments} <- find_attachments(record, attachment_def),
+           {:ok, attachments} <- find_attachments(record, attachment_def, context_opts),
            {:ok, to_purge} <- select_for_purge(attachments, attachment_def, blob_id, all?),
            {:ok, {service_mod, service_opts}} <- resolve_service(resource, attachment_def) do
         ctx = build_context(service_opts, resource, attachment_def, changeset)
 
-        case purge_attachments(to_purge, service_mod, ctx) do
+        case purge_attachments(to_purge, service_mod, ctx, context_opts) do
           {:ok, purged} ->
             {:ok, Ash.Resource.put_metadata(record, :purged_attachments, purged)}
 
@@ -65,7 +66,7 @@ defmodule AshStorage.Changes.Purge do
   end
 
   # sobelow_skip ["DOS.BinToAtom"]
-  defp find_attachments(record, attachment_def) do
+  defp find_attachments(record, attachment_def, context_opts) do
     resource = record.__struct__
     attachment_resource = Info.storage_attachment_resource!(resource)
     record_id = Map.get(record, :id) |> to_string()
@@ -92,16 +93,18 @@ defmodule AshStorage.Changes.Purge do
     attachment_resource
     |> Ash.Query.filter(^filter)
     |> Ash.Query.load(:blob)
-    |> Ash.read()
+    |> Ash.read(Keyword.take(context_opts, [:actor, :tenant, :authorize?, :tracer]))
   end
 
-  defp purge_attachments(attachments, service_mod, ctx) do
+  defp purge_attachments(attachments, service_mod, ctx, context_opts) do
+    destroy_opts = Keyword.merge(context_opts, action: :destroy, return_destroyed?: true)
+
     Enum.reduce_while(attachments, {:ok, []}, fn att, {:ok, acc} ->
       blob = att.blob
 
       with :ok <- service_mod.delete(blob.key, ctx),
-           {:ok, _} <- Ash.destroy(att, action: :destroy, return_destroyed?: true),
-           {:ok, _} <- Ash.destroy(blob, action: :destroy, return_destroyed?: true) do
+           {:ok, _} <- Ash.destroy(att, destroy_opts),
+           {:ok, _} <- Ash.destroy(blob, destroy_opts) do
         {:cont, {:ok, [att | acc]}}
       else
         {:error, error} -> {:halt, {:error, error}}

--- a/lib/ash_storage/operations.ex
+++ b/lib/ash_storage/operations.ex
@@ -313,7 +313,7 @@ defmodule AshStorage.Operations do
     resource = record.__struct__
 
     with {:ok, attachment_def} <- Info.attachment(resource, attachment_name),
-         {:ok, attachments} <- find_attachments(record, attachment_def),
+         {:ok, attachments} <- find_attachments(record, attachment_def, opts),
          {:ok, {service_mod, service_opts}} <- resolve_service(resource, attachment_def) do
       ctx = build_context(service_opts, resource, attachment_def, opts)
 
@@ -331,11 +331,11 @@ defmodule AshStorage.Operations do
   end
 
   @doc false
-  def mark_attachments_for_purge(record, attachment_name, _opts \\ []) do
+  def mark_attachments_for_purge(record, attachment_name, opts \\ []) do
     resource = record.__struct__
 
     with {:ok, attachment_def} <- Info.attachment(resource, attachment_name),
-         {:ok, attachments} <- find_attachments(record, attachment_def) do
+         {:ok, attachments} <- find_attachments(record, attachment_def, opts) do
       Enum.reduce_while(attachments, {:ok, []}, fn att, {:ok, acc} ->
         blob = att.blob
 
@@ -428,7 +428,7 @@ defmodule AshStorage.Operations do
   end
 
   # sobelow_skip ["DOS.BinToAtom"]
-  defp find_attachments(record, attachment_def) do
+  defp find_attachments(record, attachment_def, context_opts) do
     resource = record.__struct__
     attachment_resource = Info.storage_attachment_resource!(resource)
     record_id = Map.get(record, :id) |> to_string()
@@ -455,6 +455,6 @@ defmodule AshStorage.Operations do
     attachment_resource
     |> Ash.Query.filter(^filter)
     |> Ash.Query.load(:blob)
-    |> Ash.read()
+    |> Ash.read(Keyword.take(context_opts, [:actor, :tenant, :authorize?, :tracer]))
   end
 end


### PR DESCRIPTION
## The problem

Internal attachment lookups call `Ash.read()` with no options, dropping the actor and `authorize?` of the triggering action. For apps that put strict policies on their blob/attachment resources (e.g. multitenant apps gating reads by permission), every attach/detach/purge fails from the inside with `Ash.Error.Forbidden` — and `Attach.maybe_replace_existing/5` raises `CaseClauseError` on the `{:error, _}` tuple instead of returning it.

Tenant was already threaded in some sites (`Ash.Query.set_tenant`), which masks the problem until a policy actually inspects the actor.

## The fix

- Thread `context_opts` (actor/tenant/authorize?/tracer) into every `find_attachments` read: `Attach`, `AttachBlob`, `Detach`, `Purge`, `HandleDependentAttachments` (prefetch), and `Operations.destroy_attachment_and_blob_records` / `mark_attachments_for_purge`.
- Thread destroy opts through `Detach.destroy_attachment_records` and `Purge.purge_attachments`.
- Handle `{:error, _}` from `find_attachments` in both `maybe_replace_existing` implementations so policy errors propagate instead of crashing.

Behavior is unchanged for resources without policies (passing `actor: nil` explicitly is equivalent to today's bare reads).

## Known remaining (intentionally out of scope)

- `HandleFileArgument`'s upload path still runs without request scope (threading it needs the changeset-derived scope plumbed through `upload_blob/4`'s chain).
- The Oban write-attributes path (`maybe_apply_oban_write_attributes`) runs in job context with no request actor by design — probably wants a documented system-actor posture instead.

## Context

Found while adopting AshStorage as the storage engine behind a policy-strict multitenant artifact layer (workspace-scoped blob/attachment resources with `strategy :attribute` tenancy + permission-gated policies). Our integration suite (capture/idempotency/drift/cross-tenant isolation, 11 cases) runs green against this branch and is happy to be adapted as upstream regression tests if useful.