### PR TITLE
fix: forward context opts in Changes.AttachFile

### DIFF
--- a/lib/ash_storage/changes/attach_file.ex
+++ b/lib/ash_storage/changes/attach_file.ex
@@ -32,7 +32,7 @@ defmodule AshStorage.Changes.AttachFile do
   end
 
   @impl true
-  def change(changeset, opts, _context) do
+  def change(changeset, opts, context) do
     argument = opts[:argument]
     attachment = opts[:attachment]
 
@@ -43,11 +43,12 @@ defmodule AshStorage.Changes.AttachFile do
 
         %Ash.Type.File{} = file ->
           {filename, content_type} = extract_file_metadata(file)
+          context_opts = Ash.Context.to_opts(context)
 
-          case AshStorage.Operations.attach(record, attachment, file,
-                 filename: filename,
-                 content_type: content_type
-               ) do
+          attach_opts =
+            Keyword.merge(context_opts, filename: filename, content_type: content_type)
+
+          case AshStorage.Operations.attach(record, attachment, file, attach_opts) do
             {:ok, _} -> {:ok, record}
             {:error, error} -> {:error, error}
           end
@@ -59,9 +60,10 @@ defmodule AshStorage.Changes.AttachFile do
   def batch_change(changesets, _opts, _context), do: changesets
 
   @impl true
-  def after_batch(changesets_and_results, opts, _context) do
+  def after_batch(changesets_and_results, opts, context) do
     argument = opts[:argument]
     attachment = opts[:attachment]
+    context_opts = Ash.Context.to_opts(context)
 
     # Split into items that need attachment and those that don't
     {to_attach, passthrough} =
@@ -76,7 +78,11 @@ defmodule AshStorage.Changes.AttachFile do
       Enum.map(to_attach, fn {{changeset, result}, _idx} ->
         file = Ash.Changeset.get_argument(changeset, argument)
         {filename, content_type} = extract_file_metadata(file)
-        {result, attachment, file, filename: filename, content_type: content_type}
+
+        attach_opts =
+          Keyword.merge(context_opts, filename: filename, content_type: content_type)
+
+        {result, attachment, file, attach_opts}
       end)
 
     # Bulk attach

--- a/test/ash_storage/file_argument_test.exs
+++ b/test/ash_storage/file_argument_test.exs
@@ -38,6 +38,62 @@ defmodule AshStorage.FileArgumentTest do
       post = Ash.load!(post, :cover_image)
       assert post.cover_image == nil
     end
+
+    test "forwards action opts to the nested attach operation" do
+      path = Path.join(System.tmp_dir!(), "ash_storage_actor_opts_test.txt")
+      File.write!(path, "actor opts")
+
+      post =
+        AshStorage.Test.ActorRequiredPost
+        |> Ash.Changeset.for_create(
+          :create_with_image,
+          %{
+            title: "with actor",
+            cover_image: Ash.Type.File.from_path(path)
+          },
+          actor: :authorized
+        )
+        |> Ash.create!()
+
+      post = Ash.load!(post, cover_image: :blob)
+
+      assert {:ok, "actor opts"} = AshStorage.Service.Test.download(post.cover_image.blob.key, [])
+    after
+      File.rm(Path.join(System.tmp_dir!(), "ash_storage_actor_opts_test.txt"))
+    end
+
+    test "forwards action opts to nested attach operations during bulk create" do
+      path1 = Path.join(System.tmp_dir!(), "ash_storage_bulk_actor_opts_1.txt")
+      path2 = Path.join(System.tmp_dir!(), "ash_storage_bulk_actor_opts_2.txt")
+
+      File.write!(path1, "bulk actor opts 1")
+      File.write!(path2, "bulk actor opts 2")
+
+      result =
+        Ash.bulk_create(
+          [
+            %{title: "bulk 1", cover_image: Ash.Type.File.from_path(path1)},
+            %{title: "bulk 2", cover_image: Ash.Type.File.from_path(path2)}
+          ],
+          AshStorage.Test.ActorRequiredPost,
+          :create_with_image,
+          actor: :authorized,
+          return_records?: true,
+          return_errors?: true
+        )
+
+      assert result.status == :success
+      assert [post1, post2] = Ash.load!(result.records, cover_image: :blob)
+
+      assert {:ok, "bulk actor opts 1"} =
+               AshStorage.Service.Test.download(post1.cover_image.blob.key, [])
+
+      assert {:ok, "bulk actor opts 2"} =
+               AshStorage.Service.Test.download(post2.cover_image.blob.key, [])
+    after
+      File.rm(Path.join(System.tmp_dir!(), "ash_storage_bulk_actor_opts_1.txt"))
+      File.rm(Path.join(System.tmp_dir!(), "ash_storage_bulk_actor_opts_2.txt"))
+    end
   end
 
   describe "update with :file argument" do

--- a/test/support/actor_required_post.ex
+++ b/test/support/actor_required_post.ex
@@ -1,0 +1,35 @@
+defmodule AshStorage.Test.ActorRequiredPost do
+  @moduledoc false
+  use Ash.Resource,
+    domain: AshStorage.Test.Domain,
+    data_layer: Ash.DataLayer.Ets,
+    extensions: [AshStorage]
+
+  ets do
+    private? true
+  end
+
+  storage do
+    service({AshStorage.Test.ActorRequiredService, []})
+    blob_resource(AshStorage.Test.Blob)
+    attachment_resource(AshStorage.Test.PolymorphicAttachment)
+
+    has_one_attached(:cover_image)
+  end
+
+  attributes do
+    uuid_primary_key :id
+    attribute :title, :string, allow_nil?: false
+  end
+
+  actions do
+    defaults [:read, :destroy, create: [:title], update: [:title]]
+
+    create :create_with_image do
+      accept [:title]
+      argument :cover_image, :file, allow_nil?: true
+
+      change {AshStorage.Changes.AttachFile, argument: :cover_image, attachment: :cover_image}
+    end
+  end
+end

--- a/test/support/actor_required_service.ex
+++ b/test/support/actor_required_service.ex
@@ -1,0 +1,28 @@
+defmodule AshStorage.Test.ActorRequiredService do
+  @moduledoc false
+  @behaviour AshStorage.Service
+
+  @impl true
+  def upload(key, data, ctx) do
+    if ctx.actor == :authorized do
+      AshStorage.Service.Test.upload(key, data, ctx)
+    else
+      {:error, :missing_actor}
+    end
+  end
+
+  @impl true
+  def download(key, ctx), do: AshStorage.Service.Test.download(key, ctx)
+
+  @impl true
+  def delete(key, ctx), do: AshStorage.Service.Test.delete(key, ctx)
+
+  @impl true
+  def exists?(key, ctx), do: AshStorage.Service.Test.exists?(key, ctx)
+
+  @impl true
+  def url(key, ctx), do: AshStorage.Service.Test.url(key, ctx)
+
+  @impl true
+  def direct_upload(key, ctx), do: AshStorage.Service.Test.direct_upload(key, ctx)
+end

--- a/test/support/domain.ex
+++ b/test/support/domain.ex
@@ -16,6 +16,7 @@ defmodule AshStorage.Test.Domain do
     resource AshStorage.Test.IntegerAttachment
     resource AshStorage.Test.ExtraAttrsPost
     resource AshStorage.Test.ChecksumVerifyingPost
+    resource AshStorage.Test.ActorRequiredPost
     resource AshStorage.Test.NoHeadPost
     resource AshStorage.Test.MultipartEtagPost
   end


### PR DESCRIPTION
`Changes.AttachFile` did not pass the context options to the underlying ash operations. This causes that, for example when using `AshAuthorization`, the actor will be missing in the operation, and the policy will deny the operation.

I fixed it by merging the context options with the other options, and passes them down into the `attach` or `attach_many` operation.

This shouldn't be a breaking change.

# Tests

- Added a new `ActorRequiredPost` test resource together with a `ActorRequiredService` that simulates an actor being required in the options
- Added two regression tests: for a simple change, and for a bulk operation

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
