### PR TITLE
support path definition with default to tenant for attachment resource

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -14,6 +14,7 @@ spark_locals_without_parens = [
   has_many_attached: 2,
   has_one_attached: 1,
   has_one_attached: 2,
+  path: 1,
   service: 1,
   sort: 1,
   variant: 2,

--- a/lib/ash_storage.ex
+++ b/lib/ash_storage.ex
@@ -169,10 +169,10 @@ defmodule AshStorage do
   def resolve_key(attachment_def, context, changeset) do
     case attachment_def.path do
       nil ->
-        resolve_tenant_key(changeset)
+        resolve_tenant_key(changeset, context.resource)
 
       "" ->
-        resolve_tenant_key(changeset)
+        resolve_tenant_key(changeset, context.resource)
 
       path_fn when is_function(path_fn, 2) ->
         path_fn.(context, changeset)
@@ -182,16 +182,16 @@ defmodule AshStorage do
   @doc """
   Resolve the storage key for an attachment without a changeset.
   """
-  def resolve_key(attachment_def, tenant) do
+  def resolve_key_with_tenant(attachment_def, tenant, resource) do
     case attachment_def.path do
       nil ->
-        resolve_tenant_key_for_opts(tenant)
+        resolve_tenant_key_for_opts(tenant, resource)
 
       "" ->
-        resolve_tenant_key_for_opts(tenant)
+        resolve_tenant_key_for_opts(tenant, resource)
 
       path_fn when is_function(path_fn, 2) ->
-        resolve_tenant_key_for_opts(tenant)
+        resolve_tenant_key_for_opts(tenant, resource)
     end
   end
 
@@ -211,7 +211,7 @@ defmodule AshStorage do
     end
   end
 
-  defp resolve_tenant_key(changeset) do
+  defp resolve_tenant_key(changeset, resource) do
     case Map.get(changeset, :tenant) do
       nil ->
         generate_key()
@@ -223,11 +223,11 @@ defmodule AshStorage do
         Path.join([tenant, generate_key()])
 
       tenant ->
-        Path.join([to_string(tenant), generate_key()])
+        Path.join([to_string(Ash.ToTenant.to_tenant(tenant, resource)), generate_key()])
     end
   end
 
-  defp resolve_tenant_key_for_opts(tenant) do
+  defp resolve_tenant_key_for_opts(tenant, resource) do
     case tenant do
       nil ->
         generate_key()
@@ -239,7 +239,7 @@ defmodule AshStorage do
         Path.join([tenant, generate_key()])
 
       tenant ->
-        Path.join([to_string(tenant), generate_key()])
+        Path.join([to_string(Ash.ToTenant.to_tenant(tenant, resource)), generate_key()])
     end
   end
 end

--- a/lib/ash_storage.ex
+++ b/lib/ash_storage.ex
@@ -151,4 +151,95 @@ defmodule AshStorage do
   def generate_key do
     Base.encode16(:crypto.strong_rand_bytes(28), case: :lower)
   end
+
+  @doc """
+  Resolve the storage key for an attachment during upload.
+
+  Using the following priority:
+  1. Use `path` specified on the attachment definition (2-arity function) e.g.
+    has_one_attached :avatar do
+      path fn ctx, changeset ->
+      org_id = changeset.context.org_id
+      "\#{org_id}/\#{AshStorage.generate_key()}"
+    end
+  2. Tenant from the changeset i.e. "\#{tenant_id}/\#{key}"
+  3. Just the randomly generated key
+  (specified :prefix is honored in each of the priorities)
+  """
+  def resolve_key(attachment_def, context, changeset) do
+    case attachment_def.path do
+      nil ->
+        resolve_tenant_key(changeset)
+
+      "" ->
+        resolve_tenant_key(changeset)
+
+      path_fn when is_function(path_fn, 2) ->
+        path_fn.(context, changeset)
+    end
+  end
+
+  @doc """
+  Resolve the storage key for an attachment without a changeset.
+  """
+  def resolve_key(attachment_def, tenant) do
+    case attachment_def.path do
+      nil ->
+        resolve_tenant_key_for_opts(tenant)
+
+      "" ->
+        resolve_tenant_key_for_opts(tenant)
+
+      path_fn when is_function(path_fn, 2) ->
+        resolve_tenant_key_for_opts(tenant)
+    end
+  end
+
+  @doc """
+  Resolve the storage key for an attachment from the source blob's key.
+  """
+  def resolve_variant_key(source_blob_key) do
+    path =
+      String.split(source_blob_key, "/")
+      |> Enum.drop(-1)
+      |> Enum.join("/")
+
+    if byte_size(path) > 0 do
+      "#{path}/#{generate_key()}"
+    else
+      generate_key()
+    end
+  end
+
+  defp resolve_tenant_key(changeset) do
+    case Map.get(changeset, :tenant) do
+      nil ->
+        generate_key()
+
+      "" ->
+        generate_key()
+
+      tenant when is_binary(tenant) ->
+        Path.join([tenant, generate_key()])
+
+      tenant ->
+        Path.join([to_string(tenant), generate_key()])
+    end
+  end
+
+  defp resolve_tenant_key_for_opts(tenant) do
+    case tenant do
+      nil ->
+        generate_key()
+
+      "" ->
+        generate_key()
+
+      tenant when is_binary(tenant) ->
+        Path.join([tenant, generate_key()])
+
+      tenant ->
+        Path.join([to_string(tenant), generate_key()])
+    end
+  end
 end

--- a/lib/ash_storage/attachment_definition.ex
+++ b/lib/ash_storage/attachment_definition.ex
@@ -5,6 +5,7 @@ defmodule AshStorage.AttachmentDefinition do
     :type,
     :service,
     :dependent,
+    :path,
     :sort,
     :__spark_metadata__,
     analyzers: [],
@@ -28,6 +29,12 @@ defmodule AshStorage.AttachmentDefinition do
       doc:
         "What to do with the attachment when the parent record is destroyed. `:purge` deletes the blob and file, `:detach` removes the association, `false` does nothing.",
       default: :purge
+    ],
+    path: [
+      type: {:fun, 2},
+      doc:
+        "Specify a path for the key. Accepts a 2-arity function `fn ctx, changeset -> ...`. When path is not specified, falls back to the tenant if available.",
+      required: false
     ]
   ]
 

--- a/lib/ash_storage/changes/attach.ex
+++ b/lib/ash_storage/changes/attach.ex
@@ -83,9 +83,11 @@ defmodule AshStorage.Changes.Attach do
     with {:ok, attachment_def} <- Info.attachment(resource, attachment_name),
          {:ok, {service_mod, service_opts}} <- resolve_service(resource, attachment_def) do
       ctx = build_context(service_opts, resource, attachment_def, changeset)
+      key = AshStorage.resolve_key(attachment_def, ctx, changeset)
 
       with {:ok, blob} <-
              upload_and_create_blob(resource, service_mod, ctx, io, context_opts,
+               key: key,
                filename: filename,
                content_type: content_type,
                metadata: metadata
@@ -249,7 +251,7 @@ defmodule AshStorage.Changes.Attach do
     metadata = Keyword.get(opts, :metadata, %{})
 
     data = read_io(io)
-    key = AshStorage.generate_key()
+    key = Keyword.fetch!(opts, :key)
     checksum = :crypto.hash(:md5, data) |> Base.encode64()
     byte_size = byte_size(data)
 

--- a/lib/ash_storage/changes/handle_file_argument.ex
+++ b/lib/ash_storage/changes/handle_file_argument.ex
@@ -81,9 +81,11 @@ defmodule AshStorage.Changes.HandleFileArgument do
     with {:ok, attachment_def} <- Info.attachment(resource, attachment_name),
          {:ok, {service_mod, service_opts}} <- resolve_service(resource, attachment_def) do
       ctx = build_context(service_opts, resource, attachment_def, changeset)
+      key = AshStorage.resolve_key(attachment_def, ctx, changeset)
 
       with {:ok, blob} <-
              upload_and_create_blob(resource, service_mod, ctx, file,
+               key: key,
                filename: filename,
                content_type: content_type
              ),
@@ -290,7 +292,7 @@ defmodule AshStorage.Changes.HandleFileArgument do
     content_type = Keyword.get(opts, :content_type, "application/octet-stream")
 
     data = read_io(io)
-    key = AshStorage.generate_key()
+    key = Keyword.fetch!(opts, :key)
     checksum = :crypto.hash(:md5, data) |> Base.encode64()
     byte_size = byte_size(data)
 

--- a/lib/ash_storage/operations.ex
+++ b/lib/ash_storage/operations.ex
@@ -83,7 +83,7 @@ defmodule AshStorage.Operations do
       checksum = Keyword.get(arg_opts, :checksum, "")
       metadata = Keyword.get(arg_opts, :metadata, %{})
 
-      key = AshStorage.generate_key()
+      key = AshStorage.resolve_key(attachment_def, Keyword.get(opts, :tenant))
       blob_resource = Info.storage_blob_resource!(resource)
 
       with {:ok, blob} <-

--- a/lib/ash_storage/operations.ex
+++ b/lib/ash_storage/operations.ex
@@ -83,7 +83,9 @@ defmodule AshStorage.Operations do
       checksum = Keyword.get(arg_opts, :checksum, "")
       metadata = Keyword.get(arg_opts, :metadata, %{})
 
-      key = AshStorage.resolve_key(attachment_def, Keyword.get(opts, :tenant))
+      key =
+        AshStorage.resolve_key_with_tenant(attachment_def, Keyword.get(opts, :tenant), resource)
+
       blob_resource = Info.storage_blob_resource!(resource)
 
       with {:ok, blob} <-

--- a/lib/ash_storage/variant_generator.ex
+++ b/lib/ash_storage/variant_generator.ex
@@ -77,7 +77,7 @@ defmodule AshStorage.VariantGenerator do
          service_opts,
          attachment_def
        ) do
-    key = AshStorage.generate_key()
+    key = AshStorage.resolve_variant_key(source_blob.key)
     checksum = :crypto.hash(:md5, variant_data) |> Base.encode64()
     byte_size = byte_size(variant_data)
 

--- a/test/ash_storage/path_test.exs
+++ b/test/ash_storage/path_test.exs
@@ -1,0 +1,197 @@
+defmodule AshStorage.PathTest do
+  use ExUnit.Case, async: false
+
+  alias AshStorage.Info
+  alias AshStorage.Operations
+
+  describe "resolve_key/3 with path" do
+    test "uses custom path function when provided" do
+      path_fn = fn _ctx, changeset ->
+        org_id = changeset.context.tenant
+        "#{org_id}/#{AshStorage.generate_key()}"
+      end
+
+      attachment_def = %AshStorage.AttachmentDefinition{
+        name: :avatar,
+        path: path_fn
+      }
+
+      ctx = AshStorage.Service.Context.new([])
+      changeset = Ash.Changeset.for_create(AshStorage.Test.Post, :create, %{title: "test"})
+      changeset = %{changeset | context: %{tenant: "org-123"}}
+
+      key = AshStorage.resolve_key(attachment_def, ctx, changeset)
+      assert String.starts_with?(key, "org-123/")
+      refute key == "org-123/"
+    end
+
+    test "uses tenant when no custom path function is provided" do
+      attachment_def = %AshStorage.AttachmentDefinition{
+        name: :avatar
+      }
+
+      ctx = AshStorage.Service.Context.new([])
+      changeset = Ash.Changeset.for_create(AshStorage.Test.Post, :create, %{title: "test"})
+      changeset = %{changeset | tenant: "org-abc"}
+
+      key = AshStorage.resolve_key(attachment_def, ctx, changeset)
+      assert String.starts_with?(key, "org-abc")
+    end
+
+    test "falls back to a random key when no path is provided and no tenant present" do
+      attachment_def = %AshStorage.AttachmentDefinition{name: :avatar}
+      ctx = AshStorage.Service.Context.new([])
+      changeset = Ash.Changeset.for_create(AshStorage.Test.Post, :create, %{title: "test"})
+
+      key = AshStorage.resolve_key(attachment_def, ctx, changeset)
+
+      refute String.contains?(key, "/")
+      assert byte_size(key) == 56
+    end
+  end
+
+  describe "resolve_key/2 - no changeset" do
+    test "uses tenant as part of the key when path is nil" do
+      attachment_def = %AshStorage.AttachmentDefinition{name: :avatar}
+      key = AshStorage.resolve_key(attachment_def, "org-123")
+
+      assert String.starts_with?(key, "org-123/")
+      refute key == "org-123/"
+    end
+
+    test "returns just the key when path is nil and no tenant" do
+      attachment_def = %AshStorage.AttachmentDefinition{name: :avatar}
+
+      key = AshStorage.resolve_key(attachment_def, nil)
+
+      refute String.contains?(key, "/")
+      assert byte_size(key) == 56
+    end
+
+    test "returns just key when tenant is empty string" do
+      attachment_def = %AshStorage.AttachmentDefinition{name: :avatar}
+
+      key = AshStorage.resolve_key(attachment_def, "")
+
+      refute String.contains?(key, "/")
+      assert byte_size(key) == 56
+    end
+  end
+
+  describe "resolve_variant_key/1" do
+    test "preserves path from source blob key" do
+      variant_key = AshStorage.resolve_variant_key("org-test/uuid")
+      assert String.starts_with?(variant_key, "org-test/")
+      refute(variant_key == "org-test/uuid")
+    end
+
+    test "preserves nested path from source blob key" do
+      variant_key = AshStorage.resolve_variant_key("org-test/a/b/c/uuid")
+      assert String.starts_with?(variant_key, "org-test/a/b/c/")
+      refute(variant_key == "org-test/a/b/c/uuid")
+    end
+
+    test "returns just the key when source has no path" do
+      variant_key = AshStorage.resolve_variant_key("uuid")
+      refute String.contains?(variant_key, "/")
+      assert byte_size(variant_key) == 56
+    end
+  end
+
+  ## Integration tests
+
+  describe "attach/4" do
+    test "uses custom path from attachment definition" do
+      post =
+        AshStorage.Test.PathPost
+        |> Ash.Changeset.for_create(:create, %{title: "test"})
+        |> Ash.create!()
+
+      assert {:ok, %{blob: blob}} =
+               Operations.attach(post, :avatar, "avatar data",
+                 filename: "avatar.png",
+                 content_type: "image/png",
+                 actor: %{org_id: "org-42"}
+               )
+
+      assert String.starts_with?(blob.key, "org-42/")
+      assert AshStorage.Service.Test.exists?(blob.key)
+    end
+
+    test "uses tenant when there is no path specified" do
+      post =
+        AshStorage.Test.Post
+        |> Ash.Changeset.for_create(:create, %{title: "test"})
+        |> Ash.create!()
+
+      assert {:ok, %{blob: blob}} =
+               Operations.attach(post, :documents, "file data",
+                 filename: "document.pdf",
+                 content_type: "application/pdf",
+                 tenant: "tenant-abc"
+               )
+
+      assert String.starts_with?(blob.key, "tenant-abc/")
+    end
+
+    test "without path or tenant" do
+      post =
+        AshStorage.Test.Post
+        |> Ash.Changeset.for_create(:create, %{title: "test"})
+        |> Ash.create!()
+
+      assert {:ok, %{blob: blob}} =
+               Operations.attach(post, :documents, "file data",
+                 filename: "document.pdf",
+                 content_type: "application/pdf"
+               )
+
+      refute String.starts_with?(blob.key, "/")
+      assert byte_size(blob.key) == 56
+    end
+  end
+
+  ## Integration tests: direct_upload
+  describe "prepare_direct_upload" do
+    test "with tenant" do
+      {:ok, result} =
+        Operations.prepare_direct_upload(AshStorage.Test.PathPost, :avatar,
+          filename: "photo.jpg",
+          content_type: "image/jpeg",
+          byte_size: 12_345,
+          tenant: "tenant-42"
+        )
+
+      assert result.blob.filename == "photo.jpg"
+      assert String.starts_with?(result.blob.key, "tenant-42/")
+    end
+
+    test "no tenant" do
+      {:ok, result} =
+        Operations.prepare_direct_upload(AshStorage.Test.PathPost, :avatar,
+          filename: "photo.jpg",
+          content_type: "image/jpeg",
+          byte_size: 12_345
+        )
+
+      assert result.blob.filename == "photo.jpg"
+      refute String.contains?(result.blob.key, "/")
+    end
+  end
+
+  ## Tests for attachment definitions
+  describe "attachment definition path configuration" do
+    test "specified path is stored in attachment definition" do
+      {:ok, attachment_def} = Info.attachment(AshStorage.Test.PathPost, :avatar)
+
+      assert attachment_def.path != nil
+      assert is_function(attachment_def.path, 2)
+    end
+
+    test "attachment without path has no path definition" do
+      {:ok, attachment_def} = Info.attachment(AshStorage.Test.Post, :cover_image)
+
+      assert attachment_def.path == nil
+    end
+  end
+end

--- a/test/ash_storage/path_test.exs
+++ b/test/ash_storage/path_test.exs
@@ -38,6 +38,23 @@ defmodule AshStorage.PathTest do
       assert String.starts_with?(key, "org-abc")
     end
 
+    test "able to also handle tenant struct" do
+      tenant = Ash.create!(AshStorage.Test.Tenant, %{})
+
+      attachment_def = %AshStorage.AttachmentDefinition{
+        name: :avatar
+      }
+
+      ctx = AshStorage.Service.Context.new([])
+      changeset = Ash.Changeset.for_create(AshStorage.Test.Post, :create, %{title: "test"})
+      changeset = %{changeset | tenant: tenant}
+
+      key = AshStorage.resolve_key(attachment_def, ctx, changeset)
+      tenant_id = Ash.ToTenant.to_tenant(tenant, AshStorage.Test.Post)
+      assert String.starts_with?(key, "#{tenant_id}/")
+      refute key == "#{tenant_id}/"
+    end
+
     test "falls back to a random key when no path is provided and no tenant present" do
       attachment_def = %AshStorage.AttachmentDefinition{name: :avatar}
       ctx = AshStorage.Service.Context.new([])
@@ -50,19 +67,33 @@ defmodule AshStorage.PathTest do
     end
   end
 
-  describe "resolve_key/2 - no changeset" do
+  describe "resolve_key_with_tenant/3 - no changeset" do
     test "uses tenant as part of the key when path is nil" do
       attachment_def = %AshStorage.AttachmentDefinition{name: :avatar}
-      key = AshStorage.resolve_key(attachment_def, "org-123")
+
+      key =
+        AshStorage.resolve_key_with_tenant(attachment_def, "org-123", AshStorage.Test.PathPost)
 
       assert String.starts_with?(key, "org-123/")
       refute key == "org-123/"
     end
 
+    test "able to use tenant struct" do
+      tenant = Ash.create!(AshStorage.Test.Tenant, %{})
+      attachment_def = %AshStorage.AttachmentDefinition{name: :avatar}
+
+      key =
+        AshStorage.resolve_key_with_tenant(attachment_def, tenant, AshStorage.Test.PathPost)
+
+      tenant_id = Ash.ToTenant.to_tenant(tenant, AshStorage.Test.PathPost)
+      assert String.contains?(key, "#{tenant_id}/")
+      refute key == "#{tenant_id}/"
+    end
+
     test "returns just the key when path is nil and no tenant" do
       attachment_def = %AshStorage.AttachmentDefinition{name: :avatar}
 
-      key = AshStorage.resolve_key(attachment_def, nil)
+      key = AshStorage.resolve_key_with_tenant(attachment_def, nil, AshStorage.Test.PathPost)
 
       refute String.contains?(key, "/")
       assert byte_size(key) == 56
@@ -71,7 +102,7 @@ defmodule AshStorage.PathTest do
     test "returns just key when tenant is empty string" do
       attachment_def = %AshStorage.AttachmentDefinition{name: :avatar}
 
-      key = AshStorage.resolve_key(attachment_def, "")
+      key = AshStorage.resolve_key_with_tenant(attachment_def, "", AshStorage.Test.PathPost)
 
       refute String.contains?(key, "/")
       assert byte_size(key) == 56

--- a/test/support/domain.ex
+++ b/test/support/domain.ex
@@ -19,5 +19,8 @@ defmodule AshStorage.Test.Domain do
     resource AshStorage.Test.ActorRequiredPost
     resource AshStorage.Test.NoHeadPost
     resource AshStorage.Test.MultipartEtagPost
+    resource AshStorage.Test.NestedPathPost
+    resource AshStorage.Test.PathAttachment
+    resource AshStorage.Test.PathPost
   end
 end

--- a/test/support/domain.ex
+++ b/test/support/domain.ex
@@ -22,5 +22,6 @@ defmodule AshStorage.Test.Domain do
     resource AshStorage.Test.NestedPathPost
     resource AshStorage.Test.PathAttachment
     resource AshStorage.Test.PathPost
+    resource AshStorage.Test.Tenant
   end
 end

--- a/test/support/nest_path_post.ex
+++ b/test/support/nest_path_post.ex
@@ -1,0 +1,35 @@
+defmodule AshStorage.Test.NestedPathPost do
+  @moduledoc false
+  use Ash.Resource,
+    domain: AshStorage.Test.Domain,
+    data_layer: Ash.DataLayer.Ets,
+    extensions: [AshStorage]
+
+  ets do
+    private? true
+  end
+
+  storage do
+    service({AshStorage.Service.Test, []})
+    blob_resource(AshStorage.Test.Blob)
+    attachment_resource(AshStorage.Test.PathAttachment)
+
+    has_one_attached(:nested) do
+      path fn _ctx, changeset ->
+        actor = changeset.context[:private][:actor]
+        tenant_id = actor && Map.get(actor, :tenant_id)
+        org_id = actor && Map.get(actor, :org_id)
+        "#{tenant_id}/#{org_id}/#{AshStorage.generate_key()}"
+      end
+    end
+  end
+
+  attributes do
+    uuid_primary_key :id
+    attribute :title, :string, allow_nil?: false
+  end
+
+  actions do
+    defaults [:read, :destroy, create: [:title], update: [:title]]
+  end
+end

--- a/test/support/path_attachment.ex
+++ b/test/support/path_attachment.ex
@@ -1,0 +1,21 @@
+defmodule AshStorage.Test.PathAttachment do
+  @moduledoc false
+  use Ash.Resource,
+    domain: AshStorage.Test.Domain,
+    data_layer: Ash.DataLayer.Ets,
+    extensions: [AshStorage.AttachmentResource]
+
+  ets do
+    private? true
+  end
+
+  attachment do
+    blob_resource(AshStorage.Test.Blob)
+    belongs_to_resource(:path_post, AshStorage.Test.PathPost)
+    belongs_to_resource(:nested_path_post, AshStorage.Test.NestedPathPost)
+  end
+
+  attributes do
+    uuid_primary_key :id
+  end
+end

--- a/test/support/path_post.ex
+++ b/test/support/path_post.ex
@@ -1,0 +1,41 @@
+defmodule AshStorage.Test.PathPost do
+  @moduledoc false
+  use Ash.Resource,
+    domain: AshStorage.Test.Domain,
+    data_layer: Ash.DataLayer.Ets,
+    extensions: [AshStorage]
+
+  ets do
+    private? true
+  end
+
+  storage do
+    service({AshStorage.Service.Test, []})
+    blob_resource(AshStorage.Test.Blob)
+    attachment_resource(AshStorage.Test.PathAttachment)
+
+    has_one_attached(:avatar) do
+      path fn _ctx, changeset ->
+        actor = changeset.context[:private][:actor]
+        org_id = actor && Map.get(actor, :org_id)
+        "#{org_id}/#{AshStorage.generate_key()}"
+      end
+    end
+
+    has_many_attached(:files) do
+      path fn _ctx, changeset ->
+        tenant = changeset.tenant || "default"
+        "#{tenant}/#{AshStorage.generate_key()}"
+      end
+    end
+  end
+
+  attributes do
+    uuid_primary_key :id
+    attribute :title, :string, allow_nil?: false
+  end
+
+  actions do
+    defaults [:read, :destroy, create: [:title], update: [:title]]
+  end
+end

--- a/test/support/tenant.ex
+++ b/test/support/tenant.ex
@@ -1,0 +1,23 @@
+defmodule AshStorage.Test.Tenant do
+  @moduledoc false
+  use Ash.Resource,
+    domain: AshStorage.Test.Domain,
+    data_layer: Ash.DataLayer.Ets
+
+  ets do
+    private? true
+  end
+
+  actions do
+    default_accept :*
+    defaults [:read, :create, :update, :destroy]
+  end
+
+  attributes do
+    uuid_primary_key :id, writable?: true
+  end
+
+  defimpl Ash.ToTenant do
+    def to_tenant(tenant, _resource), do: tenant.id
+  end
+end


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [x] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

Addressing issue #25 
This PR adds
1. custom path definition to the attachment resource that takes an arity/2 function
2. add default tenant as key prefix if available
3. key will resolve in the following way
- use path definition
- use tenant (if available)
- just the generated random key
4. :prefix is honored and will prefix before the key as expected
5. add unit tests for path
6. add some integration tests for path

My first time working with Spark, appreciate any feedback. Please let me know if anything doesn't make sense. All tests seem to be passing.
