### PR TITLE
Fix oban analyzer writeback failing with multitenancy

### DIFF
--- a/lib/ash_storage/blob_resource/changes/run_pending_analyzers.ex
+++ b/lib/ash_storage/blob_resource/changes/run_pending_analyzers.ex
@@ -10,7 +10,7 @@ defmodule AshStorage.BlobResource.Changes.RunPendingAnalyzers do
 
   @impl true
   def change(changeset, _opts, _context) do
-    Ash.Changeset.after_action(changeset, fn _changeset, blob ->
+    Ash.Changeset.after_action(changeset, fn changeset, blob ->
       analyzers = blob.analyzers || %{}
 
       pending =
@@ -22,7 +22,7 @@ defmodule AshStorage.BlobResource.Changes.RunPendingAnalyzers do
         # sobelow_skip ["DOS.BinToAtom"]
         module = String.to_existing_atom(analyzer_mod)
 
-        case AshStorage.Operations.run_analyzer(blob, module) do
+        case AshStorage.Operations.run_analyzer(blob, module, tenant: changeset.tenant) do
           {:ok, blob} -> {:cont, {:ok, blob}}
           {:error, error} -> {:halt, {:error, error}}
         end

--- a/lib/ash_storage/changes/attach.ex
+++ b/lib/ash_storage/changes/attach.ex
@@ -50,11 +50,11 @@ defmodule AshStorage.Changes.Attach do
                :ok <- run_eager_variants(blob, attachment_def, resource),
                {:ok, blob} <- store_oban_variants(blob, attachment_def, resource) do
             if attach_context[:has_oban_analyzers?] do
-              AshOban.run_trigger(blob, :run_pending_analyzers)
+              AshOban.run_trigger(blob, :run_pending_analyzers, tenant: changeset.tenant)
             end
 
             if has_oban_variants?(attachment_def) do
-              AshOban.run_trigger(blob, :run_pending_variants)
+              AshOban.run_trigger(blob, :run_pending_variants, tenant: changeset.tenant)
             end
 
             record =
@@ -72,6 +72,7 @@ defmodule AshStorage.Changes.Attach do
   end
 
   defp do_attach(record, resource, attachment_name, changeset, context_opts) do
+    context_opts = Keyword.put(context_opts, :tenant, changeset.tenant)
     io = Ash.Changeset.get_argument(changeset, :io)
     filename = Ash.Changeset.get_argument(changeset, :filename)
 
@@ -90,7 +91,8 @@ defmodule AshStorage.Changes.Attach do
                content_type: content_type,
                metadata: metadata
              ),
-           {:ok, blob, attrs_to_write} <- run_analyzers(blob, attachment_def, record, io) do
+           {:ok, blob, attrs_to_write} <-
+             run_analyzers(blob, attachment_def, record, io, context_opts) do
         {:ok, attrs_to_write,
          %{
            blob: blob,
@@ -112,7 +114,7 @@ defmodule AshStorage.Changes.Attach do
     end)
   end
 
-  defp run_analyzers(blob, attachment_def, record, io) do
+  defp run_analyzers(blob, attachment_def, record, io, context_opts) do
     analyzer_defs = attachment_def.analyzers || []
 
     if analyzer_defs == [] do
@@ -125,7 +127,9 @@ defmodule AshStorage.Changes.Attach do
         Map.new(normalized, fn {module, _analyze, opts, write_attributes} ->
           string_opts = Map.new(opts, fn {k, v} -> {to_string(k), v} end)
 
-          entry = %{"status" => "pending", "opts" => string_opts}
+          entry =
+            %{"status" => "pending", "opts" => string_opts}
+            |> maybe_put_tenant(context_opts[:tenant])
 
           entry =
             if write_attributes != [] do
@@ -134,10 +138,14 @@ defmodule AshStorage.Changes.Attach do
 
               entry
               |> Map.put("write_attributes", string_wa)
-              |> Map.put("write_target", %{
-                "resource" => to_string(record.__struct__),
-                "id" => to_string(Map.get(record, :id))
-              })
+              |> Map.put(
+                "write_target",
+                %{
+                  "resource" => to_string(record.__struct__),
+                  "id" => to_string(Map.get(record, :id))
+                }
+                |> maybe_put_tenant(context_opts[:tenant])
+              )
             else
               entry
             end
@@ -154,20 +162,24 @@ defmodule AshStorage.Changes.Attach do
         end)
 
       with {:ok, blob} <-
-             Ash.update(blob, update_params, action: :update_metadata) do
+             Ash.update(
+               blob,
+               update_params,
+               Keyword.merge(context_opts, action: :update_metadata)
+             ) do
         eager =
           Enum.filter(normalized, fn {module, analyze, _opts, _wa} ->
             analyze != :oban && module.accept?(content_type)
           end)
 
-        run_eager_analyzers(blob, eager, io)
+        run_eager_analyzers(blob, eager, io, context_opts)
       end
     end
   end
 
-  defp run_eager_analyzers(blob, [], _io), do: {:ok, blob, %{}}
+  defp run_eager_analyzers(blob, [], _io, _context_opts), do: {:ok, blob, %{}}
 
-  defp run_eager_analyzers(blob, eager_analyzers, io) do
+  defp run_eager_analyzers(blob, eager_analyzers, io, context_opts) do
     {:ok, path} = resolve_analyzer_path(io)
 
     try do
@@ -201,7 +213,7 @@ defmodule AshStorage.Changes.Attach do
                  status: status,
                  metadata_to_merge: metadata_to_merge
                },
-               action: :complete_analysis
+               Keyword.merge(context_opts, action: :complete_analysis)
              ) do
           {:ok, blob} -> {:cont, {:ok, blob, Map.merge(acc_writes, new_writes)}}
           {:error, error} -> {:halt, {:error, error}}
@@ -211,6 +223,9 @@ defmodule AshStorage.Changes.Attach do
       maybe_cleanup_tempfile(io, path)
     end
   end
+
+  defp maybe_put_tenant(map, nil), do: map
+  defp maybe_put_tenant(map, tenant), do: Map.put(map, "tenant", tenant)
 
   # -- Service helpers --
 

--- a/lib/ash_storage/changes/handle_file_argument.ex
+++ b/lib/ash_storage/changes/handle_file_argument.ex
@@ -12,9 +12,10 @@ defmodule AshStorage.Changes.HandleFileArgument do
 
   # sobelow_skip ["DOS.BinToAtom", "Traversal.FileModule"]
   @impl true
-  def change(changeset, opts, _context) do
+  def change(changeset, opts, context) do
     argument_name = opts[:argument]
     attachment_name = opts[:attachment]
+    context_opts = Ash.Context.to_opts(context)
 
     file = Ash.Changeset.get_argument(changeset, argument_name)
 
@@ -24,8 +25,9 @@ defmodule AshStorage.Changes.HandleFileArgument do
       changeset
       |> Ash.Changeset.before_action(fn changeset ->
         resource = changeset.resource
+        context_opts = Keyword.put(context_opts, :tenant, changeset.tenant)
 
-        case upload_blob(resource, attachment_name, file, changeset) do
+        case upload_blob(resource, attachment_name, file, changeset, context_opts) do
           {:ok, attrs_to_write, context} ->
             changeset
             |> Ash.Changeset.force_change_attributes(attrs_to_write)
@@ -43,13 +45,15 @@ defmodule AshStorage.Changes.HandleFileArgument do
 
         case changeset.context[context_key] do
           %{blob: blob, attachment_def: attachment_def} = context ->
+            context_opts = Keyword.put(context_opts, :tenant, changeset.tenant)
+
             # On update, replace existing attachment; on create, skip
             with {:ok, _} <- maybe_replace_on_update(changeset, record, attachment_def, context),
                  {:ok, attachment} <- create_attachment(record, attachment_def, blob) do
               # Now that we have the record ID, update write_target for oban analyzers
               if context[:has_oban_analyzers?] do
-                update_oban_write_targets(blob, record)
-                AshOban.run_trigger(blob, :run_pending_analyzers)
+                update_oban_write_targets(blob, record, context_opts)
+                AshOban.run_trigger(blob, :run_pending_analyzers, tenant: changeset.tenant)
               end
 
               record =
@@ -75,7 +79,7 @@ defmodule AshStorage.Changes.HandleFileArgument do
     maybe_replace_existing(record, attachment_def, context[:service_mod], context[:ctx])
   end
 
-  defp upload_blob(resource, attachment_name, file, changeset) do
+  defp upload_blob(resource, attachment_name, file, changeset, context_opts) do
     {filename, content_type} = extract_file_metadata(file)
 
     with {:ok, attachment_def} <- Info.attachment(resource, attachment_name),
@@ -88,7 +92,7 @@ defmodule AshStorage.Changes.HandleFileArgument do
                content_type: content_type
              ),
            {:ok, blob, attrs_to_write} <-
-             run_analyzers(blob, attachment_def, changeset.data, file) do
+             run_analyzers(blob, attachment_def, changeset.data, file, context_opts) do
         {:ok, attrs_to_write,
          %{
            blob: blob,
@@ -102,7 +106,7 @@ defmodule AshStorage.Changes.HandleFileArgument do
   end
 
   # After create, we have the real record ID — update write_target in blob's analyzers map
-  defp update_oban_write_targets(blob, record) do
+  defp update_oban_write_targets(blob, record, context_opts) do
     analyzers = blob.analyzers || %{}
 
     has_write_targets? =
@@ -114,17 +118,26 @@ defmodule AshStorage.Changes.HandleFileArgument do
           case entry do
             %{"write_target" => _} ->
               {key,
-               Map.put(entry, "write_target", %{
-                 "resource" => to_string(record.__struct__),
-                 "id" => to_string(Map.get(record, :id))
-               })}
+               Map.put(
+                 entry,
+                 "write_target",
+                 %{
+                   "resource" => to_string(record.__struct__),
+                   "id" => to_string(Map.get(record, :id))
+                 }
+                 |> maybe_put_tenant(context_opts[:tenant])
+               )}
 
             _ ->
               {key, entry}
           end
         end)
 
-      Ash.update(blob, %{analyzers: updated}, action: :update_metadata)
+      Ash.update(
+        blob,
+        %{analyzers: updated},
+        Keyword.merge(context_opts, action: :update_metadata)
+      )
     end
   end
 
@@ -164,7 +177,7 @@ defmodule AshStorage.Changes.HandleFileArgument do
     Enum.any?(attachment_def.analyzers || [], fn defn -> defn.analyze == :oban end)
   end
 
-  defp run_analyzers(blob, attachment_def, record, io) do
+  defp run_analyzers(blob, attachment_def, record, io, context_opts) do
     analyzer_defs = attachment_def.analyzers || []
 
     if analyzer_defs == [] do
@@ -177,7 +190,9 @@ defmodule AshStorage.Changes.HandleFileArgument do
         Map.new(normalized, fn {module, _analyze, opts, write_attributes} ->
           string_opts = Map.new(opts, fn {k, v} -> {to_string(k), v} end)
 
-          entry = %{"status" => "pending", "opts" => string_opts}
+          entry =
+            %{"status" => "pending", "opts" => string_opts}
+            |> maybe_put_tenant(context_opts[:tenant])
 
           entry =
             if write_attributes != [] do
@@ -186,10 +201,14 @@ defmodule AshStorage.Changes.HandleFileArgument do
 
               entry
               |> Map.put("write_attributes", string_wa)
-              |> Map.put("write_target", %{
-                "resource" => to_string(record.__struct__),
-                "id" => to_string(Map.get(record, :id))
-              })
+              |> Map.put(
+                "write_target",
+                %{
+                  "resource" => to_string(record.__struct__),
+                  "id" => to_string(Map.get(record, :id))
+                }
+                |> maybe_put_tenant(context_opts[:tenant])
+              )
             else
               entry
             end
@@ -198,20 +217,24 @@ defmodule AshStorage.Changes.HandleFileArgument do
         end)
 
       with {:ok, blob} <-
-             Ash.update(blob, %{analyzers: initial_analyzers}, action: :update_metadata) do
+             Ash.update(
+               blob,
+               %{analyzers: initial_analyzers},
+               Keyword.merge(context_opts, action: :update_metadata)
+             ) do
         eager =
           Enum.filter(normalized, fn {module, analyze, _opts, _wa} ->
             analyze != :oban && module.accept?(content_type)
           end)
 
-        run_eager_analyzers(blob, eager, io)
+        run_eager_analyzers(blob, eager, io, context_opts)
       end
     end
   end
 
-  defp run_eager_analyzers(blob, [], _io), do: {:ok, blob, %{}}
+  defp run_eager_analyzers(blob, [], _io, _context_opts), do: {:ok, blob, %{}}
 
-  defp run_eager_analyzers(blob, eager_analyzers, io) do
+  defp run_eager_analyzers(blob, eager_analyzers, io, context_opts) do
     {:ok, path} = resolve_analyzer_path(io)
 
     try do
@@ -245,7 +268,7 @@ defmodule AshStorage.Changes.HandleFileArgument do
                  status: status,
                  metadata_to_merge: metadata_to_merge
                },
-               action: :complete_analysis
+               Keyword.merge(context_opts, action: :complete_analysis)
              ) do
           {:ok, blob} -> {:cont, {:ok, blob, Map.merge(acc_writes, new_writes)}}
           {:error, error} -> {:halt, {:error, error}}
@@ -255,6 +278,9 @@ defmodule AshStorage.Changes.HandleFileArgument do
       maybe_cleanup_tempfile(io, path)
     end
   end
+
+  defp maybe_put_tenant(map, nil), do: map
+  defp maybe_put_tenant(map, tenant), do: Map.put(map, "tenant", tenant)
 
   defp resolve_service(resource, attachment_def) do
     case Info.service_for_attachment(resource, attachment_def) do

--- a/lib/ash_storage/operations.ex
+++ b/lib/ash_storage/operations.ex
@@ -234,6 +234,13 @@ defmodule AshStorage.Operations do
 
     case Map.fetch(blob_analyzers, analyzer_key) do
       {:ok, analyzer_entry} ->
+        tenant = Keyword.get(opts, :tenant) || analyzer_entry["tenant"]
+
+        context_opts =
+          opts
+          |> Keyword.put(:tenant, tenant)
+          |> Keyword.take([:actor, :tenant, :authorize?, :tracer])
+
         analyzer_opts = analyzer_entry["opts"] || %{}
         content_type = blob.content_type || "application/octet-stream"
 
@@ -265,10 +272,14 @@ defmodule AshStorage.Operations do
                          status: status,
                          metadata_to_merge: metadata_to_merge
                        },
-                       action: :complete_analysis
+                       Keyword.merge(context_opts, action: :complete_analysis)
                      ) do
                 if status == "complete" do
-                  maybe_apply_oban_write_attributes(analyzer_entry, metadata_to_merge)
+                  maybe_apply_oban_write_attributes(
+                    analyzer_entry,
+                    metadata_to_merge,
+                    context_opts
+                  )
                 end
 
                 {:ok, blob}
@@ -281,7 +292,7 @@ defmodule AshStorage.Operations do
           Ash.update(
             blob,
             %{analyzer_key: analyzer_key, status: "skipped", metadata_to_merge: %{}},
-            action: :complete_analysis
+            Keyword.merge(context_opts, action: :complete_analysis)
           )
         end
 
@@ -358,13 +369,19 @@ defmodule AshStorage.Operations do
   # -- Private helpers --
 
   # sobelow_skip ["DOS.BinToAtom"]
-  defp maybe_apply_oban_write_attributes(analyzer_entry, metadata_to_merge) do
+  defp maybe_apply_oban_write_attributes(analyzer_entry, metadata_to_merge, context_opts) do
     write_attributes = analyzer_entry["write_attributes"]
     write_target = analyzer_entry["write_target"]
 
     if write_attributes && write_target && map_size(write_attributes) > 0 do
       resource = String.to_existing_atom(write_target["resource"])
       record_id = write_target["id"]
+      tenant = context_opts[:tenant] || write_target["tenant"]
+
+      context_opts =
+        context_opts
+        |> Keyword.put(:tenant, tenant)
+        |> Keyword.take([:actor, :tenant, :authorize?, :tracer])
 
       attrs =
         Enum.reduce(write_attributes, %{}, fn {result_key, attr_name}, acc ->
@@ -375,12 +392,12 @@ defmodule AshStorage.Operations do
         end)
 
       if map_size(attrs) > 0 do
-        case Ash.get(resource, record_id) do
+        case Ash.get(resource, record_id, context_opts) do
           {:ok, record} ->
             record
             |> Ash.Changeset.for_update(:update, %{})
             |> Ash.Changeset.force_change_attributes(attrs)
-            |> Ash.update()
+            |> Ash.update(context_opts)
 
           _ ->
             :ok

--- a/test/ash_storage/multitenancy_test.exs
+++ b/test/ash_storage/multitenancy_test.exs
@@ -82,12 +82,15 @@ defmodule AshStorage.MultitenancyTest do
       blob_resource(AshStorage.MultitenancyTest.TenantBlob)
       attachment_resource(AshStorage.MultitenancyTest.TenantAttachment)
 
-      has_one_attached(:cover_image)
+      has_one_attached :cover_image do
+        analyzer(AshStorage.Test.TestAnalyzer, write_attributes: [line_count: :cached_line_count])
+      end
     end
 
     attributes do
       uuid_primary_key :id
       attribute :title, :string, allow_nil?: false
+      attribute :cached_line_count, :integer, public?: true
     end
 
     actions do
@@ -203,6 +206,51 @@ defmodule AshStorage.MultitenancyTest do
 
       post = Ash.load!(post, [cover_image: :blob], tenant: tenant1)
       assert post.cover_image.blob.id == blob.id
+    end
+  end
+
+  describe "async analyzer write_attributes with tenant" do
+    test "writes analyzer results to the parent record in the tenant", %{tenant1: tenant1} do
+      post =
+        TenantPost
+        |> Ash.Changeset.for_create(:create, %{title: "test"}, tenant: tenant1)
+        |> Ash.create!()
+
+      {:ok, %{blob: blob}} =
+        Operations.attach(post, :cover_image, "hello\nworld\n",
+          filename: "hello.txt",
+          content_type: "text/plain",
+          tenant: tenant1
+        )
+
+      analyzer_key = to_string(AshStorage.Test.TestAnalyzer)
+
+      assert blob.analyzers[analyzer_key]["tenant"] == tenant1
+
+      analyzers = %{
+        analyzer_key => %{
+          "status" => "pending",
+          "tenant" => tenant1,
+          "opts" => %{},
+          "write_attributes" => %{"line_count" => "cached_line_count"},
+          "write_target" => %{
+            "resource" => to_string(TenantPost),
+            "id" => post.id,
+            "tenant" => tenant1
+          }
+        }
+      }
+
+      {:ok, blob} =
+        Ash.update(blob, %{analyzers: analyzers}, action: :update_metadata, tenant: tenant1)
+
+      {:ok, blob} = Operations.run_analyzer(blob, AshStorage.Test.TestAnalyzer, tenant: tenant1)
+
+      assert blob.analyzers[analyzer_key]["status"] == "complete"
+      assert blob.metadata["line_count"] == 3
+
+      post = Ash.get!(TenantPost, post.id, tenant: tenant1)
+      assert post.cached_line_count == 3
     end
   end
 end

--- a/test/ash_storage/multitenancy_test.exs
+++ b/test/ash_storage/multitenancy_test.exs
@@ -223,8 +223,6 @@ defmodule AshStorage.MultitenancyTest do
           tenant: tenant1
         )
 
-      analyzer_key = to_string(AshStorage.Test.TestAnalyzer)
-
       # Reset cached_line_count and run analyzer again to simulate async behavior
       post
       |> Ash.Changeset.for_update(:update, %{}, tenant: tenant1)
@@ -233,6 +231,7 @@ defmodule AshStorage.MultitenancyTest do
 
       {:ok, blob} = Operations.run_analyzer(blob, AshStorage.Test.TestAnalyzer)
 
+      analyzer_key = to_string(AshStorage.Test.TestAnalyzer)
       assert blob.analyzers[analyzer_key]["status"] == "complete"
       assert blob.metadata["line_count"] == 3
 

--- a/test/ash_storage/multitenancy_test.exs
+++ b/test/ash_storage/multitenancy_test.exs
@@ -225,6 +225,7 @@ defmodule AshStorage.MultitenancyTest do
 
       analyzer_key = to_string(AshStorage.Test.TestAnalyzer)
 
+      # Reset cached_line_count and run analyzer again to simulate async behavior
       post
       |> Ash.Changeset.for_update(:update, %{}, tenant: tenant1)
       |> Ash.Changeset.force_change_attribute(:cached_line_count, nil)

--- a/test/ash_storage/multitenancy_test.exs
+++ b/test/ash_storage/multitenancy_test.exs
@@ -225,26 +225,12 @@ defmodule AshStorage.MultitenancyTest do
 
       analyzer_key = to_string(AshStorage.Test.TestAnalyzer)
 
-      assert blob.analyzers[analyzer_key]["tenant"] == tenant1
+      post
+      |> Ash.Changeset.for_update(:update, %{}, tenant: tenant1)
+      |> Ash.Changeset.force_change_attribute(:cached_line_count, nil)
+      |> Ash.update!()
 
-      analyzers = %{
-        analyzer_key => %{
-          "status" => "pending",
-          "tenant" => tenant1,
-          "opts" => %{},
-          "write_attributes" => %{"line_count" => "cached_line_count"},
-          "write_target" => %{
-            "resource" => to_string(TenantPost),
-            "id" => post.id,
-            "tenant" => tenant1
-          }
-        }
-      }
-
-      {:ok, blob} =
-        Ash.update(blob, %{analyzers: analyzers}, action: :update_metadata, tenant: tenant1)
-
-      {:ok, blob} = Operations.run_analyzer(blob, AshStorage.Test.TestAnalyzer, tenant: tenant1)
+      {:ok, blob} = Operations.run_analyzer(blob, AshStorage.Test.TestAnalyzer)
 
       assert blob.analyzers[analyzer_key]["status"] == "complete"
       assert blob.metadata["line_count"] == 3


### PR DESCRIPTION
`write_attributes` in async oban analyzers silently failed when the resource is using multitenancy, because the analyzer doesn't add the tenant to db operations.

I was about to solve this in userland by using ash_oban directly instead of an ash_storage analyzer, but I really like the analyzers and the writeback feature, and would love to see this just working.

- I've fixed it by adding the tenant to opts in analyzer calls.
- The tenant is stored in the analyzer's `write_target`.

I dunno if there's a nicer solution than just passing `tenant` into everything.

# Tests

I've added a regression test to the `multitenancy_test`. I was unsure if putting it into the `analyzer_oban_test` is the better place. I've decided to put it into `multitenancy_test` because it already has the multitenancy fixture, so I'm adding less code. 

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
