### PR TITLE
[proposal] pass through tls_versions to underlying adapter

### DIFF
--- a/lib/ash_storage/service/s3.ex
+++ b/lib/ash_storage/service/s3.ex
@@ -228,10 +228,20 @@ if Code.ensure_loaded?(ReqS3) do
           resolve_credential(opts, :secret_access_key, "AWS_SECRET_ACCESS_KEY")
         )
 
+      tls_versions =
+        Keyword.get(opts, :tls_versions, "tlsv1.2")
+        |> String.split(",")
+        |> Enum.reject(&(String.trim(&1) not in ["tlsv1.2", "tlsv1.3"]))
+        |> Enum.map(&String.to_atom(String.trim(&1)))
+
+      transport_opts =
+        [transport_opts: [versions: tls_versions]]
+
       Req.new(
         base_url: "#{endpoint}/#{bucket}",
         aws_sigv4: sigv4_opts,
-        retry: :transient
+        retry: :transient,
+        connect_options: transport_opts
       )
     end
 


### PR DESCRIPTION
I thought I'd cut a PR to get some thoughts on this. I'm not sure if I'm thinking about this in the right way. I am running into this when attaching assets (not sure what changed but this was working in the past). I'm using the Backblaze B2 service.

```
[warning] Description: ~c"Failed to assert middlebox server message"
     Reason: [missing: {:change_cipher_spec, 1}]
   Location: tls_client_connection_1_3.erl:350

[notice] TLS :client: In state :hello_retry_middlebox_assert at ssl_gen_statem.erl:761 generated CLIENT ALERT: Fatal - Unexpected Message
 - {:unexpected_msg,
 {:internal,
  {:server_hello, {3, 3}, ...<snip>
```

If I understand this correctly, this is caused by the tls middlebox compatibility mode. 

This PR allow tls_versions ("tlsv1.2", "tlsv1.3") to be set and passed through to the underlying adapters - defaults to "tlsv1.2". Although, it feels a little strange having to pass in tls versions to the underlying adapter. 

It works for me when patched with `tlsv1.2` or when `middlebox_comp_mode: false` -- however, `middlebox_comp_mode` option break s3 integration tests and the tests complain that there is a `:badarg`

Other relevant information. System is
- Erlang 29
- Elixir 1.20.2-otp-29


# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
